### PR TITLE
Async pipeline with connection pooling

### DIFF
--- a/auto_video3.py
+++ b/auto_video3.py
@@ -13,15 +13,14 @@ async def main() -> None:
     except ConfigError as exc:
         raise SystemExit(str(exc))
 
-    os.environ["REPLICATE_API_TOKEN"] = config.replicate_api_key
     for d in ["image", "video", "music", "voice"]:
         Path(d).mkdir(exist_ok=True)
 
     services = create_services(config)
     pipeline = ContentPipeline(config, services)
     try:
-        result = await pipeline.run_single_video()
-        print(result)
+        results = await pipeline.run_multiple_videos(3)
+        print(results)
     except Exception as exc:
         print(f"Pipeline failed: {exc}")
 

--- a/auto_video5.py
+++ b/auto_video5.py
@@ -13,15 +13,14 @@ async def main() -> None:
     except ConfigError as exc:
         raise SystemExit(str(exc))
 
-    os.environ["REPLICATE_API_TOKEN"] = config.replicate_api_key
     for d in ["image", "video", "music", "voice"]:
         Path(d).mkdir(exist_ok=True)
 
     services = create_services(config)
     pipeline = ContentPipeline(config, services)
     try:
-        result = await pipeline.run_single_video()
-        print(result)
+        results = await pipeline.run_multiple_videos(5)
+        print(results)
     except Exception as exc:
         print(f"Pipeline failed: {exc}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+aiohttp
 python-dotenv
 replicate
 openai

--- a/services/image_generator.py
+++ b/services/image_generator.py
@@ -20,5 +20,5 @@ async def generate_image(prompt: str, config: Config) -> str:
     }
     url = await replicate_run("black-forest-labs/flux-pro", inputs, config)
     resp = await http_get(url, config)
-    await file_operations.save_file(filename, resp.content)
+    await file_operations.save_file(filename, await resp.read())
     return filename

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -67,3 +67,24 @@ async def test_pipeline_music_only(monkeypatch):
     result = await pipe.run_music_only("prompt")
     assert result == {"music": "music.mp3"}
 
+
+@pytest.mark.asyncio
+async def test_pipeline_run_multiple(monkeypatch):
+    cfg = Config("sk", "sa", "rep", 1)
+    services: Dict[str, Any] = {
+        "idea_generator": DummyIdea(),
+        "image_generator": DummyImage(),
+        "video_generator": DummyVideo(),
+        "music_generator": DummyMusic(),
+    }
+
+    async def fake_merge(video, music, voice, out):
+        return "final.mp4"
+
+    monkeypatch.setattr("pipeline.merge_video_audio", fake_merge)
+
+    pipe = ContentPipeline(cfg, services)
+    result = await pipe.run_multiple_videos(2)
+    assert len(result) == 2
+    assert all(r["video"] == "final.mp4" for r in result)
+


### PR DESCRIPTION
## Summary
- switch HTTP utilities to aiohttp and add connection pooling
- use async OpenAI client and async replicate run
- process media generation concurrently in the pipeline
- allow generating multiple videos in auto_video3/5
- add test coverage for run_multiple_videos
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c5699a2c8322a62aaebbbc3910bd