### PR TITLE
Add async test suite with mocked services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ openai
 pathlib
 pytest
 pytest-asyncio
+
+hypothesis

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from config import Config
+
+@dataclass
+class FakeResponse:
+    data: bytes
+    status: int = 200
+
+    async def read(self) -> bytes:
+        return self.data
+
+    async def json(self) -> Dict[str, Any]:
+        import json
+        return json.loads(self.data.decode())
+
+    async def text(self) -> str:
+        return self.data.decode()
+
+
+async def fake_openai_chat(prompt: str, config: Config, model: str = "gpt-4o") -> Any:
+    class Choice:
+        def __init__(self, content: str) -> None:
+            self.message = type("msg", (), {"content": content})
+
+    class Resp:
+        def __init__(self, content: str) -> None:
+            self.choices = [Choice(content)]
+
+    return Resp("Idea: Test Idea\nPrompt: test prompt")
+
+
+async def fake_openai_speech(
+    text: str, voice: str, instructions: str, config: Config
+) -> Any:
+    class Speech:
+        def __init__(self, data: bytes) -> None:
+            self.data = data
+
+        def stream_to_file(self, filename: str) -> None:
+            p = Path(filename); p.parent.mkdir(parents=True, exist_ok=True); p.write_bytes(self.data)
+
+    return Speech(b"voice")
+
+
+async def fake_replicate_run(
+    model: str, inputs: Dict[str, Any], config: Config
+) -> Any:
+    if "kling" in model:
+        class F:
+            def read(self) -> bytes:
+                return b"video"
+
+        return F()
+    return "http://dummy/image.png"
+
+
+async def fake_http_get(
+    url: str, config: Config, headers: Dict[str, str] | None = None
+) -> FakeResponse:
+    if "status" in url:
+        return FakeResponse(b"\"SUCCESS\"")
+    if "generations" in url:
+        return FakeResponse(b'{"song_paths": ["http://dummy/song.mp3"]}')
+    return FakeResponse(b"data")
+
+
+async def fake_http_post(
+    url: str, payload: Dict[str, Any], headers: Dict[str, str], config: Config
+) -> FakeResponse:
+    return FakeResponse(b'{"task_id": "123"}')
+
+
+async def async_merge(*args: Any, **kwargs: Any) -> str:
+    return "final_output.mp4"

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,40 @@
+import asyncio
+from pathlib import Path as _Path
+import sys
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from config import Config
+from pipeline import ContentPipeline
+
+
+class SleepService:
+    async def generate(self, *args, **kwargs):
+        await asyncio.sleep(0.05)
+        return "x"
+
+
+class DummyIdea:
+    async def generate(self):
+        return {"idea": "x", "prompt": "x"}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_concurrent_speed(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = Config("sk", "sa", "rep", 1)
+    services = {
+        "idea_generator": DummyIdea(),
+        "image_generator": SleepService(),
+        "video_generator": SleepService(),
+        "music_generator": SleepService(),
+    }
+    async def fake_merge(*a, **k):
+        return "out.mp4"
+    monkeypatch.setattr("pipeline.merge_video_audio", fake_merge)
+    pipe = ContentPipeline(cfg, services)
+    start = asyncio.get_event_loop().time()
+    await pipe.run_multiple_videos(3)
+    duration = asyncio.get_event_loop().time() - start
+    assert duration < 0.2
+

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,64 @@
+import asyncio
+from pathlib import Path as _Path
+import sys
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from config import Config
+from pipeline import ContentPipeline
+from services.factory import create_services
+from tests import mocks
+from utils import file_operations
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config("sk", "sa", "rep", 1)
+
+
+@pytest_asyncio.fixture(autouse=True)
+def patch_external(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = {
+        "services.image_generator.replicate_run": mocks.fake_replicate_run,
+        "services.image_generator.http_get": mocks.fake_http_get,
+        "services.idea_generator.openai_chat": mocks.fake_openai_chat,
+        "services.video_generator.replicate_run": mocks.fake_replicate_run,
+        "services.music_generator.http_post": mocks.fake_http_post,
+        "services.music_generator.http_get": mocks.fake_http_get,
+        "services.voice_generator.openai_chat": mocks.fake_openai_chat,
+        "services.voice_generator.openai_speech": mocks.fake_openai_speech,
+        "services.idea_generator.openai_chat": mocks.fake_openai_chat,
+        "pipeline.merge_video_audio": mocks.async_merge,
+    }
+    for path, func in targets.items():
+        monkeypatch.setattr(path, func)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def patch_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    async def fake_save(path: str, data: bytes) -> None:
+        p = tmp_path / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(p.write_bytes, data)
+
+    monkeypatch.setattr(file_operations, "save_file", fake_save)
+
+    monkeypatch.setattr(
+        "services.video_generator.validate_file_path",
+        lambda p, a: (tmp_path / p).resolve(),
+    )
+    async def fake_read(path: str) -> str:
+        return "[]"
+    monkeypatch.setattr(file_operations, "read_file", fake_read)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_pipeline_integration(cfg: Config) -> None:
+    services = create_services(cfg)
+    pipeline = ContentPipeline(cfg, services)
+    result = await pipeline.run_single_video()
+    assert result["video"].endswith("final_output.mp4")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,74 @@
+import asyncio
+from pathlib import Path as _Path
+import sys
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from config import Config
+from services import image_generator, video_generator, music_generator, voice_generator
+from utils import file_operations
+from tests import mocks
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config("sk", "sa", "rep", 1)
+
+
+@pytest.fixture(autouse=True)
+def patch_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(image_generator, "replicate_run", mocks.fake_replicate_run)
+    monkeypatch.setattr(image_generator, "http_get", mocks.fake_http_get)
+    monkeypatch.setattr(video_generator, "replicate_run", mocks.fake_replicate_run)
+    monkeypatch.setattr(video_generator, "validate_file_path", lambda p, a: Path(p).resolve())
+    monkeypatch.setattr(music_generator, "http_post", mocks.fake_http_post)
+    monkeypatch.setattr(music_generator, "http_get", mocks.fake_http_get)
+    monkeypatch.setattr(voice_generator, "openai_chat", mocks.fake_openai_chat)
+    monkeypatch.setattr(voice_generator, "openai_speech", mocks.fake_openai_speech)
+    monkeypatch.setattr("utils.validation.validate_file_path", lambda p, a: Path(p).resolve())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def patch_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    async def fake_save(path: str, data: bytes) -> None:
+        p = tmp_path / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(p.write_bytes, data)
+
+    monkeypatch.setattr(file_operations, "save_file", fake_save)
+    async def fake_speech(text: str, voice: str, instructions: str, config: Config):
+        class S:
+            def stream_to_file(self, filename: str) -> None:
+                f = tmp_path / filename
+                f.parent.mkdir(parents=True, exist_ok=True)
+                f.write_bytes(b"v")
+
+        return S()
+    monkeypatch.setattr(voice_generator, "openai_speech", fake_speech)
+    yield
+
+
+def test_generate_image(cfg: Config) -> None:
+    result = asyncio.run(image_generator.generate_image("prompt", cfg))
+    assert result.startswith("image/")
+
+
+def test_generate_video(cfg: Config, tmp_path: Path) -> None:
+    img = tmp_path / "image" / "img.png"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"data")
+    result = asyncio.run(video_generator.generate_video(str(img), "prompt", cfg))
+    assert result.startswith("video/")
+
+
+def test_generate_music(cfg: Config) -> None:
+    result = asyncio.run(music_generator.generate_music("idea", cfg))
+    assert result.startswith("music/")
+
+
+def test_generate_voice(cfg: Config) -> None:
+    result = asyncio.run(voice_generator.generate_voice_dialog("idea", cfg))
+    assert result["filename"].startswith("voice/")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,42 @@
+import re
+from pathlib import Path as _Path
+import sys
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings, strategies as st
+
+from utils.validation import sanitize_prompt, validate_file_path
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.text())
+def test_sanitize_prompt_valid_chars(text: str) -> None:
+    assume(text.strip())
+    cleaned = sanitize_prompt(text)
+    assert cleaned == "" or re.fullmatch(r"[\w\s.,!?'-]+", cleaned)
+
+
+def test_sanitize_prompt_invalid() -> None:
+    with pytest.raises(ValueError):
+        sanitize_prompt("")
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.text(alphabet=st.characters(blacklist_categories=["Cs", "Cc"], ), min_size=1, max_size=10))
+def test_validate_file_path_allowed(tmp_path: Path, name: str) -> None:
+    assume("/" not in name and name not in {".", ".."})
+    allowed = tmp_path / "allowed"
+    allowed.mkdir(exist_ok=True)
+    file_path = allowed / name
+    file_path.write_text("x")
+    result = validate_file_path(file_path, [allowed])
+    assert result == file_path.resolve()
+
+
+def test_validate_file_path_disallowed(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    with pytest.raises(Exception):
+        validate_file_path(tmp_path / "other" / "x.txt", [allowed])


### PR DESCRIPTION
## Summary
- add mocked API clients and async merge helpers
- create tests covering services, pipeline, validation, and performance
- include property-based input tests
- ensure async fixtures patch file and network operations

## Testing
- `pytest -q`
- `coverage run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844c75c473083229114c4f208a63750