### PR TITLE
Implement logging and metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 pytest-asyncio
 
 hypothesis
+prometheus_client

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,40 @@
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from config import Config
+from pipeline import ContentPipeline
+from utils.monitoring import PIPELINE_SUCCESS, PIPELINE_FAILURE
+
+
+class DummyIdea:
+    async def generate(self):
+        return {"idea": "x", "prompt": "x"}
+
+
+class DummyGen:
+    async def generate(self, *args, **kwargs):
+        return "x"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_metrics(monkeypatch):
+    cfg = Config("k1", "k2", "k3", 1)
+    services = {
+        "idea_generator": DummyIdea(),
+        "image_generator": DummyGen(),
+        "video_generator": DummyGen(),
+        "music_generator": DummyGen(),
+    }
+    async def fake_merge(*a, **k):
+        return "out.mp4"
+    monkeypatch.setattr("pipeline.merge_video_audio", fake_merge)
+    start_success = PIPELINE_SUCCESS._value.get()
+    pipe = ContentPipeline(cfg, services)
+    await pipe.run_single_video()
+    assert PIPELINE_SUCCESS._value.get() == start_success + 1
+    assert PIPELINE_FAILURE._value.get() == 0

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,19 +1,28 @@
 import asyncio
-from typing import Callable, TypeVar, Awaitable
+import logging
+from typing import Awaitable, Callable, TypeVar
 
 from exceptions import APIError, NetworkError
+from utils.monitoring import API_RESPONSE_TIME
 
 T = TypeVar("T")
 
 
 async def api_call_with_retry(operation_name: str, api_call: Callable[[], Awaitable[T]], max_retries: int = 3, timeout: int = 60) -> T:
+    logger = logging.getLogger(__name__)
+    loop = asyncio.get_event_loop()
     for attempt in range(max_retries):
+        start = loop.time()
         try:
-            return await asyncio.wait_for(api_call(), timeout=timeout)
+            result = await asyncio.wait_for(api_call(), timeout=timeout)
+            API_RESPONSE_TIME.labels(operation=operation_name).observe(loop.time() - start)
+            return result
         except asyncio.TimeoutError as exc:
+            logger.warning("%s timeout", operation_name, extra={"attempt": attempt + 1})
             if attempt == max_retries - 1:
                 raise NetworkError(f"{operation_name} timed out") from exc
         except Exception as exc:
+            logger.warning("%s failed: %s", operation_name, exc, extra={"attempt": attempt + 1})
             if attempt == max_retries - 1:
                 raise APIError(f"{operation_name} failed: {exc}") from exc
         await asyncio.sleep(2 ** attempt)

--- a/utils/file_operations.py
+++ b/utils/file_operations.py
@@ -2,6 +2,8 @@ import asyncio
 from pathlib import Path
 from typing import Iterable
 
+from utils.monitoring import FILE_PROCESS_TIME
+
 from .validation import validate_file_path
 from exceptions import FileError
 
@@ -14,16 +16,24 @@ def _resolve(path: str, allowed: Iterable[str]) -> Path:
 
 async def read_file(path: str) -> str:
     file_path = _resolve(path, ["prompts", "image", "video", "music", "voice", "."])  # allow reading from these
+    loop = asyncio.get_event_loop()
+    start = loop.time()
     try:
         return await asyncio.to_thread(file_path.read_text)
     except OSError as exc:
         raise FileError(str(exc)) from exc
+    finally:
+        FILE_PROCESS_TIME.labels(operation="read_file").observe(loop.time() - start)
 
 
 async def save_file(path: str, data: bytes) -> None:
     file_path = _resolve(path, ["image", "video", "music", "voice"])
     file_path.parent.mkdir(parents=True, exist_ok=True)
+    loop = asyncio.get_event_loop()
+    start = loop.time()
     try:
         await asyncio.to_thread(file_path.write_bytes, data)
     except OSError as exc:
         raise FileError(str(exc)) from exc
+    finally:
+        FILE_PROCESS_TIME.labels(operation="save_file").observe(loop.time() - start)

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -1,0 +1,25 @@
+import json
+import logging
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        data: Dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "name": record.name,
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+        }
+        for key, value in record.__dict__.items():
+            if key not in vars(logging.LogRecord("","",0,0,"",[],None)):
+                data[key] = value
+        return json.dumps(data)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.addHandler(handler)

--- a/utils/monitoring.py
+++ b/utils/monitoring.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aiohttp import web
+from prometheus_client import Counter, Histogram, start_http_server
+
+API_RESPONSE_TIME = Histogram(
+    "api_response_time_seconds", "API response times", ["operation"]
+)
+FILE_PROCESS_TIME = Histogram(
+    "file_processing_seconds", "File processing durations", ["operation"]
+)
+PIPELINE_SUCCESS = Counter("pipeline_success_total", "Successful pipeline runs")
+PIPELINE_FAILURE = Counter("pipeline_failure_total", "Failed pipeline runs")
+
+
+async def start_health_server(port: int) -> web.AppRunner:
+    app = web.Application()
+    app.router.add_get("/health", lambda request: web.json_response({"status": "ok"}))
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+    return runner
+
+
+def start_metrics_server(port: int) -> None:
+    start_http_server(port)
+


### PR DESCRIPTION
## Summary
- add JSON logging formatter and setup
- collect Prometheus metrics for API, file, and pipeline events
- expose health check and metrics servers
- record metrics in `api_call_with_retry`, file ops, and pipeline
- test new monitoring functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ce14d134832282de629f5244a940