### PR TITLE
Add CLI and FastAPI interfaces

### DIFF
--- a/ai_video_pipeline/api_app.py
+++ b/ai_video_pipeline/api_app.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Dict
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from config import load_config, get_pipeline_config, PipelineConfig
+from pipeline import ContentPipeline
+from services.factory import create_services
+from utils.logging_config import setup_logging
+
+app = FastAPI()
+_jobs: Dict[str, Dict[str, str | int]] = {}
+
+
+class GenerationRequest(BaseModel):
+    idea_type: str = Field(default="general", max_length=50)
+    video_count: int = Field(default=get_pipeline_config().video_batch_small, ge=1, le=10)
+    duration: int = Field(default=get_pipeline_config().default_video_duration, ge=1, le=60)
+    output_dir: str = Field(default="outputs")
+    config_file: str | None = None
+
+
+def _load_custom(path: str) -> PipelineConfig:
+    data = json.loads(Path(path).read_text())
+    base = get_pipeline_config()
+    for k, v in data.items():
+        setattr(base, k, v)
+    return base
+
+
+async def _run_job(job_id: str, req: GenerationRequest) -> None:
+    cfg = load_config()
+    if req.config_file:
+        cfg.pipeline = _load_custom(req.config_file)
+    cfg.pipeline.default_video_duration = req.duration
+    services = create_services(cfg)
+    pipe = ContentPipeline(cfg, services)
+    _jobs[job_id]["status"] = "running"
+    try:
+        result = await pipe.run_multiple_videos(req.video_count)
+        out_dir = Path(req.output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for idx, item in enumerate(result):
+            Path(item["video"]).rename(out_dir / f"video_{idx}.mp4")
+        _jobs[job_id]["status"] = "completed"
+    except Exception as exc:
+        _jobs[job_id]["status"] = "failed"
+        _jobs[job_id]["error"] = str(exc)
+
+
+@app.post("/generate")
+async def generate_content(req: GenerationRequest) -> Dict[str, str]:
+    job_id = uuid4().hex
+    _jobs[job_id] = {"status": "pending"}
+    asyncio.create_task(_run_job(job_id, req))
+    return {"job_id": job_id}
+
+
+@app.get("/status/{job_id}")
+async def job_status(job_id: str) -> Dict[str, str | int]:
+    if job_id not in _jobs:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return _jobs[job_id]
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    setup_logging()

--- a/ai_video_pipeline/cli.py
+++ b/ai_video_pipeline/cli.py
@@ -1,0 +1,54 @@
+import argparse
+import asyncio
+from pathlib import Path
+from typing import List
+
+from config import load_config, get_pipeline_config, PipelineConfig
+from pipeline import ContentPipeline
+from services.factory import create_services
+from utils.logging_config import setup_logging
+
+
+def _load_custom_config(path: str) -> PipelineConfig:
+    text = Path(path).read_text()
+    import json
+    data = json.loads(text)
+    base = get_pipeline_config()
+    for k, v in data.items():
+        setattr(base, k, v)
+    return base
+
+
+async def _run_generate(args: argparse.Namespace) -> None:
+    setup_logging()
+    cfg = load_config()
+    if args.config_file:
+        cfg.pipeline = _load_custom_config(args.config_file)
+    cfg.pipeline.default_video_duration = args.duration
+    services = create_services(cfg)
+    pipe = ContentPipeline(cfg, services)
+    result = await pipe.run_multiple_videos(args.video_count)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, item in enumerate(result):
+        dest = out_dir / f"video_{idx}.mp4"
+        Path(item["video"]).rename(dest)
+    print({"videos": [str((out_dir / f"video_{i}.mp4")) for i in range(len(result))]})
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="ai_video_pipeline")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    gen = sub.add_parser("generate")
+    gen.add_argument("--idea-type", default="general")
+    gen.add_argument("--video-count", type=int, default=get_pipeline_config().video_batch_small)
+    gen.add_argument("--duration", type=int, default=get_pipeline_config().default_video_duration)
+    gen.add_argument("--output-dir", default="outputs")
+    gen.add_argument("--config-file")
+    args = parser.parse_args(argv)
+    if args.cmd == "generate":
+        asyncio.run(_run_generate(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ pytest-asyncio
 
 hypothesis
 prometheus_client
+fastapi
+httpx
+

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,26 @@
+import asyncio
+from pathlib import Path as _Path
+import sys
+
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ai_video_pipeline import api_app
+
+
+@pytest.fixture(autouse=True)
+def patch_run(monkeypatch):
+    async def fake_run(job_id, req):
+        api_app._jobs[job_id]["status"] = "completed"
+    monkeypatch.setattr(api_app, '_run_job', fake_run)
+
+
+def test_generate_and_status(monkeypatch):
+    client = TestClient(api_app.app)
+    resp = client.post('/generate', json={})
+    assert resp.status_code == 200
+    job = resp.json()['job_id']
+    status = client.get(f'/status/{job}')
+    assert status.json()['status'] == 'completed'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import asyncio
+from pathlib import Path as _Path
+import sys
+
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from ai_video_pipeline import cli
+
+
+class DummyPipe:
+    def __init__(self, cfg, services):
+        self.tmp = _Path(cfg.pipeline.history_file).parent
+
+    async def run_multiple_videos(self, count):
+        paths = []
+        for i in range(count):
+            p = self.tmp / f"in{i}.mp4"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"v")
+            paths.append({"video": str(p)})
+        return paths
+
+
+def test_cli_generate(monkeypatch, tmp_path):
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test-openai1234567890')
+    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-test-sonauto123456')
+    monkeypatch.setenv('REPLICATE_API_KEY', 'rep-test-replicate123456')
+    monkeypatch.setattr(cli, 'ContentPipeline', lambda cfg, services: DummyPipe(cfg, services))
+    monkeypatch.setattr(cli, 'create_services', lambda cfg: {})
+    monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))
+    out = tmp_path / 'out'
+    cli.main(['generate', '--video-count', '2', '--output-dir', str(out)])
+    assert (out / 'video_0.mp4').exists()
+    assert (out / 'video_1.mp4').exists()


### PR DESCRIPTION
## Summary
- add CLI module with generate command
- add FastAPI app for asynchronous generation
- include tests for new CLI and API server
- update requirements for FastAPI and httpx

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cfc54eec8322937dd9eaafa18b93