### PR TITLE
Improve API key security

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,9 +22,9 @@ class DummyPipe:
 
 
 def test_cli_generate(monkeypatch, tmp_path):
-    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test-openai1234567890')
-    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-test-sonauto123456')
-    monkeypatch.setenv('REPLICATE_API_KEY', 'rep-test-replicate123456')
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-testopenai1234567890abcd')
+    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890abcd')
+    monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890abcd')
     monkeypatch.setattr(cli, 'ContentPipeline', lambda cfg, services: DummyPipe(cfg, services))
     monkeypatch.setattr(cli, 'create_services', lambda cfg: {})
     monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,13 +4,13 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from config import load_config, ConfigError, load_pipeline_config
+from config import load_config, reload_config, ConfigError, load_pipeline_config
 
 
 def test_load_config_success(monkeypatch):
-    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test-openai1234567890')
-    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-test-sonauto123456')
-    monkeypatch.setenv('REPLICATE_API_KEY', 'rep-test-replicate123456')
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-testopenai1234567890abcd')
+    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890')
+    monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890')
     cfg = load_config()
     assert cfg.openai_api_key.startswith('sk-')
     assert cfg.api_timeout == 60
@@ -20,7 +20,7 @@ def test_load_config_success(monkeypatch):
 def test_load_config_missing(monkeypatch):
     monkeypatch.delenv('OPENAI_API_KEY', raising=False)
     monkeypatch.setenv('SONAUTO_API_KEY', 'sa-test')
-    monkeypatch.setenv('REPLICATE_API_KEY', 'rep-test')
+    monkeypatch.setenv('REPLICATE_API_KEY', 'r8_test')
     with pytest.raises(ConfigError):
         load_config()
 
@@ -29,3 +29,13 @@ def test_pipeline_env_override(monkeypatch):
     monkeypatch.setenv('PIPELINE_ENV', 'staging')
     cfg = load_pipeline_config('staging')
     assert cfg.api_timeout == 180
+
+
+def test_reload_config(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-firstkey1234567890abcd')
+    monkeypatch.setenv('SONAUTO_API_KEY', 'sa-firstkey1234567890abcd')
+    monkeypatch.setenv('REPLICATE_API_KEY', 'r8_firstkey1234567890abcd')
+    cfg1 = load_config()
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-secondkey1234567890abcd')
+    cfg2 = reload_config()
+    assert cfg1.openai_api_key != cfg2.openai_api_key


### PR DESCRIPTION
## Summary
- strengthen key format validation and add `reload_config`
- update tests for stricter key validation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d905cc6c832291f53323087898b8