### PR TITLE
Implement DI container for services

### DIFF
--- a/ai_video_pipeline/api_app.py
+++ b/ai_video_pipeline/api_app.py
@@ -39,8 +39,8 @@ async def _run_job(job_id: str, req: GenerationRequest) -> None:
     if req.config_file:
         cfg.pipeline = _load_custom(req.config_file)
     cfg.pipeline.default_video_duration = req.duration
-    services = create_services(cfg)
-    pipe = ContentPipeline(cfg, services)
+    container = create_services(cfg)
+    pipe = ContentPipeline(cfg, container)
     _jobs[job_id]["status"] = "running"
     try:
         result = await pipe.run_multiple_videos(req.video_count)

--- a/ai_video_pipeline/cli.py
+++ b/ai_video_pipeline/cli.py
@@ -29,8 +29,8 @@ async def _run_generate(args: argparse.Namespace) -> None:
     if args.config_file:
         cfg.pipeline = _load_custom_config(args.config_file)
     cfg.pipeline.default_video_duration = args.duration
-    services = create_services(cfg)
-    pipe = ContentPipeline(cfg, services)
+    container = create_services(cfg)
+    pipe = ContentPipeline(cfg, container)
     result = await pipe.run_multiple_videos(args.video_count)
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ async def _prepare(config_env: str | None) -> tuple[Any, ContentPipeline]:
     cfg = await load_config_async(config_env)
     for d in ["image", "video", "music", "voice"]:
         Path(d).mkdir(exist_ok=True)
-    services = create_services(cfg)
-    pipe = ContentPipeline(cfg, services)
+    container = create_services(cfg)
+    pipe = ContentPipeline(cfg, container)
     return cfg, pipe
 
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,16 @@
+from .interfaces import IdeaGeneratorInterface, MediaGeneratorInterface
+from .idea_generator import IdeaGeneratorService
+from .image_generator import ImageGeneratorService
+from .video_generator import VideoGeneratorService
+from .music_generator import MusicGeneratorService
+from .voice_generator import VoiceGeneratorService
+
+__all__ = [
+    "IdeaGeneratorInterface",
+    "MediaGeneratorInterface",
+    "IdeaGeneratorService",
+    "ImageGeneratorService",
+    "VideoGeneratorService",
+    "MusicGeneratorService",
+    "VoiceGeneratorService",
+]

--- a/services/container.py
+++ b/services/container.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+class Container:
+    """Simple dependency injection container."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, Callable[[], Any]] = {}
+        self._instances: Dict[str, Any] = {}
+
+    def register_singleton(self, name: str, provider: Callable[[], Any]) -> None:
+        self._providers[name] = provider
+
+    def get(self, name: str, default: Any | None = None) -> Any:
+        if name not in self._instances:
+            provider = self._providers.get(name)
+            if provider is None:
+                return default
+            self._instances[name] = provider()
+        return self._instances[name]
+
+    def __getitem__(self, name: str) -> Any:
+        return self.get(name)
+
+    def clear(self) -> None:
+        self._providers.clear()
+        self._instances.clear()

--- a/services/factory.py
+++ b/services/factory.py
@@ -1,56 +1,20 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from config import Config
-from . import idea_generator, image_generator, video_generator, music_generator, voice_generator
+
+from .container import Container
+from .idea_generator import IdeaGeneratorService
+from .image_generator import ImageGeneratorService
+from .video_generator import VideoGeneratorService
+from .music_generator import MusicGeneratorService
+from .voice_generator import VoiceGeneratorService
 
 
-class IdeaService:
-    def __init__(self, config: Config) -> None:
-        self.config = config
-
-    async def generate(self) -> Dict[str, str]:
-        return await idea_generator.generate_idea(self.config)
-
-
-class ImageService:
-    def __init__(self, config: Config) -> None:
-        self.config = config
-
-    async def generate(self, prompt: str) -> str:
-        return await image_generator.generate_image(prompt, self.config)
-
-
-class VideoService:
-    def __init__(self, config: Config) -> None:
-        self.config = config
-
-    async def generate(self, image_path: str, prompt: str) -> str:
-        return await video_generator.generate_video(image_path, prompt, self.config)
-
-
-class MusicService:
-    def __init__(self, config: Config) -> None:
-        self.config = config
-
-    async def generate(self, prompt: str) -> str:
-        return await music_generator.generate_music(prompt, self.config)
-
-
-class VoiceService:
-    def __init__(self, config: Config) -> None:
-        self.config = config
-
-    async def generate(self, idea: str) -> Dict[str, str]:
-        return await voice_generator.generate_voice_dialog(idea, self.config)
-
-
-def create_services(config: Config) -> Dict[str, Any]:
-    return {
-        "idea_generator": IdeaService(config),
-        "image_generator": ImageService(config),
-        "video_generator": VideoService(config),
-        "music_generator": MusicService(config),
-        "voice_generator": VoiceService(config),
-    }
+def create_services(config: Config, container: Container | None = None) -> Container:
+    container = container or Container()
+    container.register_singleton("idea_generator", lambda: IdeaGeneratorService(config))
+    container.register_singleton("image_generator", lambda: ImageGeneratorService(config))
+    container.register_singleton("video_generator", lambda: VideoGeneratorService(config))
+    container.register_singleton("music_generator", lambda: MusicGeneratorService(config))
+    container.register_singleton("voice_generator", lambda: VoiceGeneratorService(config))
+    return container

--- a/services/idea_generator.py
+++ b/services/idea_generator.py
@@ -1,31 +1,50 @@
+from __future__ import annotations
+
 import json
 import time
-from typing import Dict
+from typing import Dict, List
 
 from config import Config
 from utils import file_operations
 from utils.api_clients import openai_chat
+from .interfaces import IdeaGeneratorInterface
+
+
+class IdeaGeneratorService(IdeaGeneratorInterface):
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def generate(self) -> Dict[str, str]:
+        history = await self.get_history()
+        base = await file_operations.read_file("prompts/idea_gen.txt")
+        prompt = base
+        if history:
+            avoid = "\n\nPlease avoid generating ideas similar to:\n" + "\n".join(
+                f"{i+1}. {idea}" for i, idea in enumerate(history)
+            )
+            prompt += avoid
+        response = await openai_chat(prompt, self.config)
+        content = response.choices[0].message.content
+        idea_part, _, prompt_part = content.partition("Prompt:")
+        idea = " ".join(idea_part.replace("Idea:", "").replace("*", "").split())
+        result = {"idea": idea.strip(), "prompt": prompt_part.strip()}
+        history.append(result["idea"])
+        history = history[-self.config.pipeline.max_stored_ideas :]
+        await file_operations.save_file(
+            self.config.pipeline.history_file, json.dumps(history).encode()
+        )
+        return result
+
+    async def get_history(self) -> List[str]:
+        try:
+            data = await file_operations.read_file(self.config.pipeline.history_file)
+            return json.loads(data)
+        except Exception:
+            return []
+
+    async def clear_history(self) -> None:
+        await file_operations.save_file(self.config.pipeline.history_file, b"[]")
 
 
 async def generate_idea(config: Config) -> Dict[str, str]:
-    history_file = config.pipeline.history_file
-    base = await file_operations.read_file("prompts/idea_gen.txt")
-    try:
-        history = json.loads(await file_operations.read_file(history_file))
-    except Exception:
-        history = []
-    prompt = base
-    if history:
-        avoid = "\n\nPlease avoid generating ideas similar to:\n" + "\n".join(
-            f"{i+1}. {idea}" for i, idea in enumerate(history)
-        )
-        prompt += avoid
-    response = await openai_chat(prompt, config)
-    content = response.choices[0].message.content
-    idea_part, _, prompt_part = content.partition("Prompt:")
-    idea = " ".join(idea_part.replace("Idea:", "").replace("*", "").split())
-    result = {"idea": idea.strip(), "prompt": prompt_part.strip()}
-    history.append(result["idea"])
-    history = history[-config.pipeline.max_stored_ideas:]
-    await file_operations.save_file(history_file, json.dumps(history).encode())
-    return result
+    return await IdeaGeneratorService(config).generate()

--- a/services/image_generator.py
+++ b/services/image_generator.py
@@ -1,24 +1,42 @@
+from __future__ import annotations
+
 import time
 from pathlib import Path
+from typing import List
 
 from config import Config
 from utils.validation import sanitize_prompt
 from utils import file_operations
 from utils.api_clients import replicate_run, http_get
+from .interfaces import MediaGeneratorInterface
+
+
+class ImageGeneratorService(MediaGeneratorInterface):
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        prompt = sanitize_prompt(prompt)
+        filename = f"image/flux_image_{int(time.time())}.png"
+        inputs = {
+            "width": 768,
+            "height": 1344,
+            "prompt": prompt,
+            "output_format": "png",
+            "aspect_ratio": "9:16",
+            "safety_tolerance": 6,
+        }
+        url = await replicate_run("black-forest-labs/flux-pro", inputs, self.config)
+        resp = await http_get(url, self.config)
+        await file_operations.save_file(filename, await resp.read())
+        return filename
+
+    async def get_supported_formats(self) -> List[str]:
+        return ["png"]
+
+    async def validate_input(self, **kwargs) -> bool:
+        return bool(kwargs.get("prompt"))
 
 
 async def generate_image(prompt: str, config: Config) -> str:
-    prompt = sanitize_prompt(prompt)
-    filename = f"image/flux_image_{int(time.time())}.png"
-    inputs = {
-        "width": 768,
-        "height": 1344,
-        "prompt": prompt,
-        "output_format": "png",
-        "aspect_ratio": "9:16",
-        "safety_tolerance": 6,
-    }
-    url = await replicate_run("black-forest-labs/flux-pro", inputs, config)
-    resp = await http_get(url, config)
-    await file_operations.save_file(filename, await resp.read())
-    return filename
+    return await ImageGeneratorService(config).generate(prompt)

--- a/services/interfaces.py
+++ b/services/interfaces.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Dict, List, Protocol
+
+
+class IdeaGeneratorInterface(Protocol):
+    async def generate(self) -> Dict[str, str]:
+        ...
+
+    async def get_history(self) -> List[str]:
+        ...
+
+    async def clear_history(self) -> None:
+        ...
+
+
+class MediaGeneratorInterface(Protocol):
+    async def generate(self, prompt: str, **kwargs) -> str:  # pragma: no cover - interface
+        ...
+
+    async def get_supported_formats(self) -> List[str]:
+        ...
+
+    async def validate_input(self, **kwargs) -> bool:
+        ...

--- a/services/music_generator.py
+++ b/services/music_generator.py
@@ -1,58 +1,74 @@
+from __future__ import annotations
+
 import asyncio
 import time
-from typing import Dict
+from typing import Dict, List
 
 from config import Config
 from utils.validation import sanitize_prompt
 from utils import file_operations
 from utils.api_clients import http_post, http_get
 from exceptions import APIError, NetworkError
+from .interfaces import MediaGeneratorInterface
 
 
-async def _wait_for_music(task_id: str, headers: Dict[str, str], config: Config) -> str:
-    for _ in range(20):
-        await asyncio.sleep(5)
-        status = await http_get(
-            f"https://api.sonauto.ai/v1/generations/status/{task_id}",
-            config,
-            headers,
-        )
-        if status.status != 200:
-            raise APIError(await status.text())
-        state = (await status.text()).strip('"')
-        if state == "FAILURE":
-            raise APIError("Music generation failed")
-        if state == "SUCCESS":
-            result = await http_get(
-                f"https://api.sonauto.ai/v1/generations/{task_id}",
-                config,
+class MusicGeneratorService(MediaGeneratorInterface):
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def _wait_for_music(self, task_id: str, headers: Dict[str, str]) -> str:
+        for _ in range(20):
+            await asyncio.sleep(5)
+            status = await http_get(
+                f"https://api.sonauto.ai/v1/generations/status/{task_id}",
+                self.config,
                 headers,
             )
-            if result.status != 200:
-                raise APIError(await result.text())
-            data = await result.json()
-            return data["song_paths"][0]
-    raise NetworkError("Music generation timed out")
+            if status.status != 200:
+                raise APIError(await status.text())
+            state = (await status.text()).strip('"')
+            if state == "FAILURE":
+                raise APIError("Music generation failed")
+            if state == "SUCCESS":
+                result = await http_get(
+                    f"https://api.sonauto.ai/v1/generations/{task_id}",
+                    self.config,
+                    headers,
+                )
+                if result.status != 200:
+                    raise APIError(await result.text())
+                data = await result.json()
+                return data["song_paths"][0]
+        raise NetworkError("Music generation timed out")
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        prompt = sanitize_prompt(prompt)
+        filename = f"music/sonauto_music_{int(time.time())}.mp3"
+        payload = {
+            "prompt": prompt,
+            "tags": ["ethereal", "chants"],
+            "instrumental": True,
+            "prompt_strength": 2.3,
+            "output_format": "mp3",
+        }
+        headers = {
+            "Authorization": f"Bearer {self.config.sonauto_api_key}",
+            "Content-Type": "application/json",
+        }
+        resp = await http_post("https://api.sonauto.ai/v1/generations", payload, headers, self.config)
+        data = await resp.json()
+        task_id = data["task_id"]
+        url = await self._wait_for_music(task_id, headers)
+        song = await http_get(url, self.config, None)
+        await file_operations.save_file(filename, await song.read())
+        return filename
+
+    async def get_supported_formats(self) -> List[str]:
+        return ["mp3"]
+
+    async def validate_input(self, **kwargs) -> bool:
+        return bool(kwargs.get("prompt"))
 
 
 async def generate_music(prompt: str, config: Config) -> str:
-    prompt = sanitize_prompt(prompt)
-    filename = f"music/sonauto_music_{int(time.time())}.mp3"
-    payload = {
-        "prompt": prompt,
-        "tags": ["ethereal", "chants"],
-        "instrumental": True,
-        "prompt_strength": 2.3,
-        "output_format": "mp3",
-    }
-    headers = {
-        "Authorization": f"Bearer {config.sonauto_api_key}",
-        "Content-Type": "application/json",
-    }
-    resp = await http_post("https://api.sonauto.ai/v1/generations", payload, headers, config)
-    data = await resp.json()
-    task_id = data["task_id"]
-    url = await _wait_for_music(task_id, headers, config)
-    song = await http_get(url, config, None)
-    await file_operations.save_file(filename, await song.read())
-    return filename
+    return await MusicGeneratorService(config).generate(prompt)

--- a/services/registry.py
+++ b/services/registry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+from config import Config
+
+from .container import Container
+from .factory import create_services
+
+_container: Container | None = None
+
+
+def init_services(config: Config) -> Container:
+    global _container
+    _container = create_services(config)
+    return _container
+
+
+def get_service(name: str) -> Any:
+    if _container is None:
+        raise RuntimeError("Services not initialized")
+    return _container[name]
+
+
+def get_container() -> Container:
+    if _container is None:
+        raise RuntimeError("Services not initialized")
+    return _container
+
+
+def clear_services() -> None:
+    global _container
+    if _container is not None:
+        _container.clear()
+    _container = None

--- a/services/video_generator.py
+++ b/services/video_generator.py
@@ -1,27 +1,46 @@
+from __future__ import annotations
+
 import time
 from pathlib import Path
+from typing import List
 
 from config import Config
 from utils.validation import sanitize_prompt, validate_file_path
 from utils import file_operations
 from utils.api_clients import replicate_run
+from .interfaces import MediaGeneratorInterface
+
+
+class VideoGeneratorService(MediaGeneratorInterface):
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        image_path = kwargs.get("image_path")
+        if not image_path:
+            raise ValueError("image_path is required")
+        img = validate_file_path(Path(image_path), [Path("image")])
+        prompt = sanitize_prompt(prompt)
+        filename = f"video/kling_video_{int(time.time())}.mp4"
+        settings = {
+            "aspect_ratio": "9:16",
+            "cfg_scale": 0.5,
+            "duration": self.config.pipeline.default_video_duration,
+        }
+        async def call() -> bytes:
+            with open(img, "rb") as f:
+                inp = {**settings, "prompt": prompt, "start_image": f}
+                return await replicate_run("kwaivgi/kling-v1.6-standard", inp, self.config)
+        output = await call()
+        await file_operations.save_file(filename, output.read())
+        return filename
+
+    async def get_supported_formats(self) -> List[str]:
+        return ["mp4"]
+
+    async def validate_input(self, **kwargs) -> bool:
+        return Path(kwargs.get("image_path", "")).suffix in {".png", ".jpg", ".jpeg"}
 
 
 async def generate_video(image_path: str, prompt: str, config: Config) -> str:
-    img = validate_file_path(Path(image_path), [Path("image")])
-    prompt = sanitize_prompt(prompt)
-    filename = f"video/kling_video_{int(time.time())}.mp4"
-    settings = {
-        "aspect_ratio": "9:16",
-        "cfg_scale": 0.5,
-        "duration": config.pipeline.default_video_duration,
-    }
-
-    async def call() -> bytes:
-        with open(img, "rb") as f:
-            inp = {**settings, "prompt": prompt, "start_image": f}
-            return await replicate_run("kwaivgi/kling-v1.6-standard", inp, config)
-
-    output = await call()
-    await file_operations.save_file(filename, output.read())
-    return filename
+    return await VideoGeneratorService(config).generate(prompt, image_path=image_path)

--- a/services/voice_generator.py
+++ b/services/voice_generator.py
@@ -1,28 +1,46 @@
+from __future__ import annotations
+
 import asyncio
 import time
-from typing import Dict
+from typing import Dict, List
 
 from config import Config
 from utils import file_operations
 from utils.api_clients import openai_chat, openai_speech
 from utils.validation import sanitize_prompt
+from .interfaces import MediaGeneratorInterface
+
+
+class VoiceGeneratorService(MediaGeneratorInterface):
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def generate(self, prompt: str, **kwargs) -> Dict[str, str]:
+        idea = sanitize_prompt(prompt)
+        examples = await file_operations.read_file("prompts/voice_examples.txt")
+        chat_prompt = f"Create a brief question for: {idea}\n{examples}"
+        chat = await openai_chat(chat_prompt, self.config)
+        content = chat.choices[0].message.content
+        fields = {
+            k.lower(): v.strip().strip('"')
+            for line in content.split("\n")
+            if ':' in line
+            for k, v in [line.split(':', 1)]
+        }
+        dialog = fields.get("dialog", "")
+        instructions = fields.get("instructions", "Speak naturally")
+        voice = "shimmer" if "shimmer" in fields.get("voice", "").lower() else "onyx"
+        speech = await openai_speech(dialog, voice, instructions, self.config)
+        filename = f"voice/openai_voice_{int(time.time())}.mp3"
+        await asyncio.to_thread(speech.stream_to_file, filename)
+        return {"filename": filename, "dialog": dialog, "voice": voice, "instructions": instructions}
+
+    async def get_supported_formats(self) -> List[str]:
+        return ["mp3"]
+
+    async def validate_input(self, **kwargs) -> bool:
+        return bool(kwargs.get("prompt"))
 
 
 async def generate_voice_dialog(idea: str, config: Config) -> Dict[str, str]:
-    idea = sanitize_prompt(idea)
-    examples = await file_operations.read_file("prompts/voice_examples.txt")
-    prompt = f"Create a brief question for: {idea}\n{examples}"
-    chat = await openai_chat(prompt, config)
-    content = chat.choices[0].message.content
-    fields = {
-        k.lower(): v.strip().strip('"')
-        for line in content.split("\n") if ':' in line
-        for k, v in [line.split(':', 1)]
-    }
-    dialog = fields.get('dialog', '')
-    instructions = fields.get('instructions', 'Speak naturally')
-    voice = 'shimmer' if 'shimmer' in fields.get('voice', '').lower() else 'onyx'
-    speech = await openai_speech(dialog, voice, instructions, config)
-    filename = f"voice/openai_voice_{int(time.time())}.mp3"
-    await asyncio.to_thread(speech.stream_to_file, filename)
-    return {"filename": filename, "dialog": dialog, "voice": voice, "instructions": instructions}
+    return await VoiceGeneratorService(config).generate(idea)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
 from ai_video_pipeline import cli
+from services import container
 
 
 class DummyPipe:
@@ -26,7 +27,7 @@ def test_cli_generate(monkeypatch, tmp_path):
     monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890abcd')
     monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890abcd')
     monkeypatch.setattr(cli, 'ContentPipeline', lambda cfg, services: DummyPipe(cfg, services))
-    monkeypatch.setattr(cli, 'create_services', lambda cfg: {})
+    monkeypatch.setattr(cli, 'create_services', lambda cfg: container.Container())
     monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))
     out = tmp_path / 'out'
     cli.main(['generate', '--video-count', '2', '--output-dir', str(out)])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
 import main
+from services import container
 
 
 class DummyPipe:
@@ -32,7 +33,7 @@ def _patch(monkeypatch):
     monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890abcd')
     monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890abcd')
     monkeypatch.setattr(main, 'ContentPipeline', lambda cfg, svc: DummyPipe(cfg, svc))
-    monkeypatch.setattr(main, 'create_services', lambda cfg: {})
+    monkeypatch.setattr(main, 'create_services', lambda cfg: container.Container())
     monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))
 
 

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -58,7 +58,7 @@ async def patch_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_pipeline_integration(cfg: Config) -> None:
-    services = create_services(cfg)
-    pipeline = ContentPipeline(cfg, services)
+    container = create_services(cfg)
+    pipeline = ContentPipeline(cfg, container)
     result = await pipeline.run_single_video()
     assert result["video"].endswith("final_output.mp4")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,7 +8,14 @@ import pytest
 import pytest_asyncio
 
 from config import Config
-from services import image_generator, video_generator, music_generator, voice_generator
+import services.image_generator as image_module
+import services.video_generator as video_module
+import services.music_generator as music_module
+import services.voice_generator as voice_module
+from services.image_generator import ImageGeneratorService
+from services.video_generator import VideoGeneratorService
+from services.music_generator import MusicGeneratorService
+from services.voice_generator import VoiceGeneratorService
 from utils import file_operations
 from tests import mocks
 
@@ -20,14 +27,14 @@ def cfg() -> Config:
 
 @pytest.fixture(autouse=True)
 def patch_clients(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(image_generator, "replicate_run", mocks.fake_replicate_run)
-    monkeypatch.setattr(image_generator, "http_get", mocks.fake_http_get)
-    monkeypatch.setattr(video_generator, "replicate_run", mocks.fake_replicate_run)
-    monkeypatch.setattr(video_generator, "validate_file_path", lambda p, a: Path(p).resolve())
-    monkeypatch.setattr(music_generator, "http_post", mocks.fake_http_post)
-    monkeypatch.setattr(music_generator, "http_get", mocks.fake_http_get)
-    monkeypatch.setattr(voice_generator, "openai_chat", mocks.fake_openai_chat)
-    monkeypatch.setattr(voice_generator, "openai_speech", mocks.fake_openai_speech)
+    monkeypatch.setattr(image_module, "replicate_run", mocks.fake_replicate_run)
+    monkeypatch.setattr(image_module, "http_get", mocks.fake_http_get)
+    monkeypatch.setattr(video_module, "replicate_run", mocks.fake_replicate_run)
+    monkeypatch.setattr(video_module, "validate_file_path", lambda p, a: Path(p).resolve())
+    monkeypatch.setattr(music_module, "http_post", mocks.fake_http_post)
+    monkeypatch.setattr(music_module, "http_get", mocks.fake_http_get)
+    monkeypatch.setattr(voice_module, "openai_chat", mocks.fake_openai_chat)
+    monkeypatch.setattr(voice_module, "openai_speech", mocks.fake_openai_speech)
     monkeypatch.setattr("utils.validation.validate_file_path", lambda p, a: Path(p).resolve())
 
 
@@ -47,12 +54,13 @@ async def patch_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
                 f.write_bytes(b"v")
 
         return S()
-    monkeypatch.setattr(voice_generator, "openai_speech", fake_speech)
+    monkeypatch.setattr(voice_module, "openai_speech", fake_speech)
     yield
 
 
 def test_generate_image(cfg: Config) -> None:
-    result = asyncio.run(image_generator.generate_image("prompt", cfg))
+    svc = ImageGeneratorService(cfg)
+    result = asyncio.run(svc.generate("prompt"))
     assert result.startswith("image/")
 
 
@@ -60,20 +68,24 @@ def test_generate_video(cfg: Config, tmp_path: Path) -> None:
     img = tmp_path / "image" / "img.png"
     img.parent.mkdir(parents=True)
     img.write_bytes(b"data")
-    result = asyncio.run(video_generator.generate_video(str(img), "prompt", cfg))
+    svc = VideoGeneratorService(cfg)
+    result = asyncio.run(svc.generate("prompt", image_path=str(img)))
     assert result.startswith("video/")
 
 
 def test_generate_music(cfg: Config) -> None:
-    result = asyncio.run(music_generator.generate_music("idea", cfg))
+    svc = MusicGeneratorService(cfg)
+    result = asyncio.run(svc.generate("idea"))
     assert result.startswith("music/")
 
 
 def test_generate_voice(cfg: Config) -> None:
-    result = asyncio.run(voice_generator.generate_voice_dialog("idea", cfg))
+    svc = VoiceGeneratorService(cfg)
+    result = asyncio.run(svc.generate("idea"))
     assert result["filename"].startswith("voice/")
 
 
 def test_generate_voice_invalid(cfg: Config) -> None:
+    svc = VoiceGeneratorService(cfg)
     with pytest.raises(ValueError):
-        asyncio.run(voice_generator.generate_voice_dialog("", cfg))
+        asyncio.run(svc.generate(""))


### PR DESCRIPTION
## Summary
- introduce `IdeaGeneratorInterface` and `MediaGeneratorInterface`
- create a simple DI container and service registry
- refactor generator services into classes implementing interfaces
- update factory and pipeline to use the container
- adjust CLI, API app, and main entry points
- update tests for new container-based services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e134f7c483229eb83afdf22b86ef