### PR TITLE
Add health monitoring system

### DIFF
--- a/monitoring/alerting.py
+++ b/monitoring/alerting.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .health_checks import ServiceHealthChecker
+from .metrics_collector import MetricsCollector
+from .performance_tracker import PerformanceTracker
+
+
+@dataclass
+class Alert:
+    service: str
+    message: str
+
+
+class AlertManager:
+    def __init__(
+        self,
+        collector: MetricsCollector,
+        checker: ServiceHealthChecker,
+        tracker: PerformanceTracker,
+    ) -> None:
+        self.collector = collector
+        self.checker = checker
+        self.tracker = tracker
+
+    async def evaluate(self) -> List[Alert]:
+        alerts: List[Alert] = []
+        health = await self.checker.get_overall_health()
+        for h in health.services:
+            if not h.healthy:
+                alerts.append(Alert(h.service, h.details or "unhealthy"))
+        for service, errors in self.collector.errors.items():
+            calls = self.collector.calls.get(service, 1)
+            if errors / calls > 0.05:
+                alerts.append(Alert(service, "error rate high"))
+        for service, count in self.collector.calls.items():
+            if self.tracker.check_deviation(service, self.collector.RESPONSE_TIME.labels(service=service)._sum.get() / count):
+                alerts.append(Alert(service, "response time degraded"))
+        return alerts

--- a/monitoring/health_checks.py
+++ b/monitoring/health_checks.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List
+
+from config import Config
+from utils.api_clients import openai_chat, replicate_run, http_get
+from utils.media_processing import merge_video_audio
+from exceptions import ServiceError
+
+
+@dataclass
+class HealthStatus:
+    service: str
+    healthy: bool
+    details: str = ""
+
+
+@dataclass
+class SystemHealthStatus:
+    services: List[HealthStatus] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        return all(s.healthy for s in self.services)
+
+
+class ServiceHealthChecker:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    async def check_openai_health(self) -> HealthStatus:
+        try:
+            await openai_chat("ping", self.config)
+            return HealthStatus("openai", True)
+        except Exception as exc:
+            return HealthStatus("openai", False, str(exc))
+
+    async def check_replicate_health(self) -> HealthStatus:
+        try:
+            await replicate_run("black-forest-labs/flux-pro", {"prompt": "test"}, self.config)
+            return HealthStatus("replicate", True)
+        except Exception as exc:
+            return HealthStatus("replicate", False, str(exc))
+
+    async def check_sonauto_health(self) -> HealthStatus:
+        try:
+            await http_get("https://api.sonauto.ai/health", self.config)
+            return HealthStatus("sonauto", True)
+        except Exception as exc:
+            return HealthStatus("sonauto", False, str(exc))
+
+    async def check_ffmpeg_health(self) -> HealthStatus:
+        try:
+            await merge_video_audio("", "", None, "", 1)
+        except ServiceError:
+            # merge_video_audio raises error if paths invalid; this means ffmpeg exists
+            return HealthStatus("ffmpeg", True)
+        except Exception as exc:
+            return HealthStatus("ffmpeg", False, str(exc))
+        return HealthStatus("ffmpeg", True)
+
+    async def get_overall_health(self) -> SystemHealthStatus:
+        results = await asyncio.gather(
+            self.check_openai_health(),
+            self.check_replicate_health(),
+            self.check_sonauto_health(),
+            self.check_ffmpeg_health(),
+        )
+        return SystemHealthStatus(list(results))

--- a/monitoring/metrics_collector.py
+++ b/monitoring/metrics_collector.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from prometheus_client import Counter, Gauge, Histogram
+
+
+class MetricsCollector:
+    RESPONSE_TIME = Histogram("service_response_seconds", "Service response time", ["service"])
+    ERROR_COUNT = Counter("service_errors_total", "Service error count", ["service", "type"])
+    QUEUE_DEPTH = Gauge("queue_depth", "Queue depth", ["queue"])
+    RESOURCE_USAGE = Gauge("resource_usage_percent", "Resource utilization", ["resource"])
+    API_QUOTA = Gauge("api_quota_usage_percent", "API quota usage", ["service"])
+
+    def __init__(self) -> None:
+        self.calls: Dict[str, int] = {}
+        self.errors: Dict[str, int] = {}
+
+    def observe_response(self, service: str, duration: float) -> None:
+        self.calls[service] = self.calls.get(service, 0) + 1
+        self.RESPONSE_TIME.labels(service=service).observe(duration)
+
+    def increment_error(self, service: str, err_type: str) -> None:
+        self.errors[service] = self.errors.get(service, 0) + 1
+        self.ERROR_COUNT.labels(service=service, type=err_type).inc()
+
+    def set_queue_depth(self, queue: str, depth: int) -> None:
+        self.QUEUE_DEPTH.labels(queue=queue).set(depth)
+
+    def update_resource_usage(self) -> None:
+        cpu = os.getloadavg()[0] * 100
+        self.RESOURCE_USAGE.labels(resource="cpu").set(cpu)
+
+    def set_api_quota(self, service: str, used: float, limit: float) -> None:
+        if limit:
+            percent = used / limit * 100
+            self.API_QUOTA.labels(service=service).set(percent)

--- a/monitoring/performance_tracker.py
+++ b/monitoring/performance_tracker.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+class PerformanceTracker:
+    def __init__(self) -> None:
+        self.baseline: Dict[str, float] = {}
+
+    def check_deviation(self, service: str, value: float) -> bool:
+        base = self.baseline.get(service)
+        if base is None:
+            self.baseline[service] = value
+            return False
+        if base == 0:
+            return False
+        return value > base * 1.5

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -83,7 +83,7 @@ async def run_pipeline(config: Config) -> Dict[str, str]:
 
     setup_logging()
     start_metrics_server(8000)
-    await start_health_server(8001)
+    await start_health_server(config, 8001)
     container = create_services(config)
     pipeline = ContentPipeline(config, container)
     return await pipeline.run_single_video()

--- a/tests/test_health_checks.py
+++ b/tests/test_health_checks.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import asyncio
+import pytest
+
+from config import Config
+from monitoring.health_checks import ServiceHealthChecker, HealthStatus, SystemHealthStatus
+
+
+class DummyChecker(ServiceHealthChecker):
+    async def check_openai_health(self) -> HealthStatus:
+        return HealthStatus("openai", True)
+
+    async def check_replicate_health(self) -> HealthStatus:
+        return HealthStatus("replicate", True)
+
+    async def check_sonauto_health(self) -> HealthStatus:
+        return HealthStatus("sonauto", True)
+
+    async def check_ffmpeg_health(self) -> HealthStatus:
+        return HealthStatus("ffmpeg", True)
+
+
+@pytest.mark.asyncio
+async def test_overall_health():
+    cfg = Config("k1", "k2", "k3", 60)
+    checker = DummyChecker(cfg)
+    status = await checker.get_overall_health()
+    assert isinstance(status, SystemHealthStatus)
+    assert status.healthy
+    assert len(status.services) == 4

--- a/tests/test_metrics_alerting.py
+++ b/tests/test_metrics_alerting.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import asyncio
+import pytest
+
+from monitoring.metrics_collector import MetricsCollector
+from monitoring.performance_tracker import PerformanceTracker
+from monitoring.alerting import AlertManager, Alert
+from monitoring.health_checks import ServiceHealthChecker, HealthStatus, SystemHealthStatus
+from config import Config
+
+
+class DummyChecker(ServiceHealthChecker):
+    async def get_overall_health(self) -> SystemHealthStatus:
+        return SystemHealthStatus([HealthStatus("openai", True)])
+
+
+@pytest.mark.asyncio
+async def test_alerting_on_errors():
+    collector = MetricsCollector()
+    tracker = PerformanceTracker()
+    checker = DummyChecker(Config("k1", "k2", "k3", 60))
+    manager = AlertManager(collector, checker, tracker)
+    collector.observe_response("svc", 1.0)
+    collector.increment_error("svc", "fail")
+    alerts = await manager.evaluate()
+    assert any(a.message == "error rate high" for a in alerts)
+
+
+def test_performance_tracker():
+    tracker = PerformanceTracker()
+    assert not tracker.check_deviation("svc", 1.0)
+    assert not tracker.check_deviation("svc", 1.2)
+    assert tracker.check_deviation("svc", 2.0)


### PR DESCRIPTION
## Summary
- introduce ServiceHealthChecker with detailed health checks
- add metrics collector, performance tracker and alert manager
- integrate monitoring utilities with new modules
- record metrics in service generators
- expose health server using new components
- add tests for monitoring components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ec9d96d88322a766215a600dfe00