### PR TITLE
Add persistence and recovery modules

### DIFF
--- a/storage/backup_manager.py
+++ b/storage/backup_manager.py
@@ -1,0 +1,46 @@
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+import zipfile
+
+from .integrity_checker import IntegrityChecker
+
+
+class BackupManager:
+    def __init__(self, data_dirs: List[str], backup_dir: str = "backups", retention_days: int = 30) -> None:
+        self.data_dirs = [Path(d) for d in data_dirs]
+        self.backup_dir = Path(backup_dir)
+        self.backup_dir.mkdir(parents=True, exist_ok=True)
+        self.retention = timedelta(days=retention_days)
+        self.integrity = IntegrityChecker()
+
+    async def _archive(self, name: str) -> Path:
+        path = self.backup_dir / f"{name}.zip"
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for d in self.data_dirs:
+                for file in d.rglob("*"):
+                    if file.is_file():
+                        zf.write(file, file.relative_to(d.parent))
+        checksum = await self.integrity.sha256(path)
+        await self.integrity.update_checksum_file(self.backup_dir / "checksums.json", path.name, checksum)
+        return path
+
+    async def incremental_backup(self) -> Path:
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M")
+        return await self._archive(f"inc_{ts}")
+
+    async def full_backup(self) -> Path:
+        ts = datetime.utcnow().strftime("%Y%m%d")
+        return await self._archive(f"full_{ts}")
+
+    async def cleanup_backups(self) -> None:
+        now = datetime.utcnow()
+        for p in self.backup_dir.glob("*.zip"):
+            mtime = datetime.utcfromtimestamp(p.stat().st_mtime)
+            if now - mtime > self.retention:
+                await asyncio.to_thread(p.unlink)
+                checks = await self.integrity.load_checksums(self.backup_dir / "checksums.json")
+                if p.name in checks:
+                    del checks[p.name]
+                    await self.integrity.update_checksum_file(self.backup_dir / "checksums.json", p.name, checks.get(p.name, ""))

--- a/storage/integrity_checker.py
+++ b/storage/integrity_checker.py
@@ -1,0 +1,43 @@
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict
+
+from exceptions import FileOperationError
+
+
+class IntegrityChecker:
+    async def sha256(self, path: Path) -> str:
+        try:
+            data = await asyncio.to_thread(path.read_bytes)
+        except OSError as exc:
+            raise FileOperationError(str(exc)) from exc
+        return hashlib.sha256(data).hexdigest()
+
+    async def verify(self, path: Path, checksum: str) -> bool:
+        return await self.sha256(path) == checksum
+
+    async def update_checksum_file(self, file: Path, name: str, checksum: str) -> None:
+        if file.exists():
+            try:
+                content = await asyncio.to_thread(file.read_text)
+                data = json.loads(content)
+            except OSError:
+                data = {}
+        else:
+            data = {}
+        data[name] = checksum
+        try:
+            await asyncio.to_thread(file.write_text, json.dumps(data))
+        except OSError as exc:
+            raise FileOperationError(str(exc)) from exc
+
+    async def load_checksums(self, file: Path) -> Dict[str, str]:
+        if not file.exists():
+            return {}
+        try:
+            content = await asyncio.to_thread(file.read_text)
+            return json.loads(content)
+        except OSError as exc:
+            raise FileOperationError(str(exc)) from exc

--- a/storage/persistence.py
+++ b/storage/persistence.py
@@ -1,0 +1,61 @@
+import asyncio
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+
+from typing import Any, TYPE_CHECKING
+from exceptions import FileOperationError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pipeline.stages import PipelineContext
+else:
+    PipelineContext = Any
+
+
+@dataclass
+class PipelineState:
+    stage: str
+    context: PipelineContext
+
+
+class PipelineStateManager:
+    def __init__(self, base_dir: str = "state") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    async def save_state(self, pipeline_id: str, state: PipelineState) -> None:
+        path = self.base_dir / f"{pipeline_id}.json"
+        data = json.dumps({"stage": state.stage, "context": asdict(state.context)})
+        try:
+            await asyncio.to_thread(path.write_text, data)
+        except OSError as exc:
+            raise FileOperationError(str(exc)) from exc
+
+    async def load_state(self, pipeline_id: str) -> PipelineState:
+        path = self.base_dir / f"{pipeline_id}.json"
+        if not path.exists():
+            from pipeline.stages import PipelineContext as PC
+            return PipelineState("", PC())
+        try:
+            data = await asyncio.to_thread(path.read_text)
+            payload = json.loads(data)
+        except OSError as exc:
+            raise FileOperationError(str(exc)) from exc
+        from pipeline.stages import PipelineContext as PC
+        ctx = PC(**payload.get("context", {}))
+        return PipelineState(payload.get("stage", ""), ctx)
+
+    async def list_recoverable_pipelines(self) -> List[str]:
+        return [p.stem for p in self.base_dir.glob("*.json")]
+
+    async def cleanup_old_states(self, max_age: timedelta) -> None:
+        now = datetime.utcnow()
+        for p in self.base_dir.glob("*.json"):
+            try:
+                mtime = datetime.utcfromtimestamp(p.stat().st_mtime)
+                if now - mtime > max_age:
+                    await asyncio.to_thread(p.unlink)
+            except OSError:
+                continue

--- a/storage/recovery_manager.py
+++ b/storage/recovery_manager.py
@@ -1,0 +1,18 @@
+import asyncio
+from pathlib import Path
+import zipfile
+
+from .persistence import PipelineStateManager, PipelineState
+
+
+class RecoveryManager:
+    def __init__(self, backup_dir: str = "backups") -> None:
+        self.backup_dir = Path(backup_dir)
+
+    async def restore_backup(self, archive_name: str, target_dir: str) -> None:
+        path = self.backup_dir / archive_name
+        with zipfile.ZipFile(path, "r") as zf:
+            await asyncio.to_thread(zf.extractall, target_dir)
+
+    async def recover_pipeline(self, pipeline_id: str, manager: PipelineStateManager) -> PipelineState:
+        return await manager.load_state(pipeline_id)

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -2,6 +2,7 @@ import asyncio
 from pathlib import Path
 import sys
 import os
+import json
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -10,11 +11,15 @@ from exceptions import FileError
 
 
 @pytest.mark.asyncio
-async def test_read_write(tmp_path: Path):
+async def test_read_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(file_operations, "BASE_DIR", tmp_path)
+    monkeypatch.chdir(tmp_path)
     file_path = 'image/test_unit.txt'
     await file_operations.save_file(file_path, b'hello')
     content = await file_operations.read_file(file_path)
     assert content == 'hello'
+    checks = json.loads((tmp_path / 'image' / '.checksums.json').read_text())
+    assert file_path.split('/')[-1] in checks
 
 
 @pytest.mark.asyncio
@@ -27,3 +32,15 @@ async def test_invalid_path(tmp_path: Path):
 async def test_path_traversal(tmp_path: Path):
     with pytest.raises(FileError):
         await file_operations.read_file('../secret.txt')
+
+
+@pytest.mark.asyncio
+async def test_checksum_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(file_operations, "BASE_DIR", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    path = 'image/bad.txt'
+    await file_operations.save_file(path, b'data')
+    file = tmp_path / path
+    file.write_bytes(b'changed')
+    with pytest.raises(FileError):
+        await file_operations.read_file(path)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,55 @@
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from storage.persistence import PipelineStateManager, PipelineState
+from storage.integrity_checker import IntegrityChecker
+from storage.backup_manager import BackupManager
+from storage.recovery_manager import RecoveryManager
+from pipeline.stages import PipelineContext
+
+
+@pytest.mark.asyncio
+async def test_pipeline_state_manager(tmp_path: Path) -> None:
+    mgr = PipelineStateManager(base_dir=tmp_path)
+    state = PipelineState("stage", PipelineContext(idea="x"))
+    await mgr.save_state("p1", state)
+    loaded = await mgr.load_state("p1")
+    assert loaded.stage == "stage"
+    assert loaded.context.idea == "x"
+    lst = await mgr.list_recoverable_pipelines()
+    assert "p1" in lst
+    await mgr.cleanup_old_states(timedelta(seconds=0))
+    assert not (tmp_path / "p1.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_integrity_checker(tmp_path: Path) -> None:
+    f = tmp_path / "a.txt"
+    f.write_text("data")
+    checker = IntegrityChecker()
+    cs = await checker.sha256(f)
+    assert await checker.verify(f, cs)
+    f.write_text("bad")
+    assert not await checker.verify(f, cs)
+
+
+@pytest.mark.asyncio
+async def test_backup_and_recovery(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "f.txt").write_text("x")
+    bm = BackupManager([data], backup_dir=tmp_path / "bkp", retention_days=0)
+    arc = await bm.incremental_backup()
+    (data / "f.txt").unlink()
+    rm = RecoveryManager(backup_dir=tmp_path / "bkp")
+    await rm.restore_backup(arc.name, tmp_path / "out")
+    restored = (tmp_path / "out" / "data" / "f.txt").read_text()
+    assert restored == "x"
+    await bm.cleanup_backups()
+    assert not any((tmp_path / "bkp").glob("*.zip"))


### PR DESCRIPTION
## Summary
- add new storage modules for persistence, backups, recovery and integrity checking
- integrate checksum validation into file operations
- persist pipeline state via `PipelineStateManager`
- test persistence, backup recovery and checksum features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ef04ab888322b316975e580ae50e