### PR TITLE
Fix retry jitter and testing workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,21 @@
+name: Quality
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Cleanup Coverage Database
+        run: rm -f .coverage
+      - name: Run Tests
+        run: pytest --cov=./ --cov-report=xml

--- a/tests/test_metrics_alerting.py
+++ b/tests/test_metrics_alerting.py
@@ -26,7 +26,7 @@ async def test_alerting_on_errors():
     collector.observe_response("svc", 1.0)
     collector.increment_error("svc", "fail")
     alerts = await manager.evaluate()
-    assert any(a.message == "error rate high" for a in alerts)
+    assert any(a.message == "error rate high" for a in alerts), "No error rate high alert generated"
 
 
 def test_performance_tracker():

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-import random
+import secrets
 from typing import Awaitable, Callable, TypeVar
 
 from exceptions import (
@@ -47,5 +47,5 @@ async def api_call_with_retry(
             if attempts == policy.max_attempts - 1:
                 raise APIError(f"{operation_name} failed: {exc}") from exc
         attempts += 1
-        await asyncio.sleep((2 ** attempts) + random.random())
+        await asyncio.sleep((2 ** attempts) + secrets.SystemRandom().random())
     raise APIError(f"{operation_name} failed after retries")


### PR DESCRIPTION
## Summary
- use `secrets.SystemRandom` for jitter in `api_call_with_retry`
- improve assertion messaging in metrics alerting test
- add quality workflow with coverage cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844fa1d87b08322a395ec2f1d35596a