### PR TITLE
Implement task queue and worker infrastructure

### DIFF
--- a/infrastructure/autoscaler.py
+++ b/infrastructure/autoscaler.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+
+from .task_queue import TaskQueue
+from .worker_manager import WorkerManager
+
+
+class Autoscaler:
+    def __init__(
+        self,
+        queue: TaskQueue,
+        manager: WorkerManager,
+        min_workers: int = 1,
+        max_workers: int = 10,
+        threshold: int = 5,
+    ) -> None:
+        self.queue = queue
+        self.manager = manager
+        self.min_workers = min_workers
+        self.max_workers = max_workers
+        self.threshold = threshold
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._monitor())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+
+    async def _monitor(self) -> None:
+        while True:
+            depth = self.queue._queue.qsize()
+            count = self.manager.worker_count
+            if depth > self.threshold and count < self.max_workers:
+                await self.manager.scale(count + 1)
+            elif depth == 0 and count > self.min_workers:
+                await self.manager.scale(count - 1)
+            await asyncio.sleep(1)
+

--- a/infrastructure/load_balancer.py
+++ b/infrastructure/load_balancer.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import asyncio
+from itertools import cycle
+from typing import Iterable
+
+
+class LoadBalancer:
+    """Round-robin load balancer for API endpoints."""
+
+    def __init__(self, endpoints: Iterable[str]) -> None:
+        self._endpoints = cycle(endpoints)
+        self._lock = asyncio.Lock()
+
+    async def get_endpoint(self) -> str:
+        async with self._lock:
+            return next(self._endpoints)
+

--- a/infrastructure/resource_monitor.py
+++ b/infrastructure/resource_monitor.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Dict
+
+
+def _get_cpu_usage() -> float:
+    try:
+        load1, _, _ = os.getloadavg()
+        return load1
+    except OSError:
+        return 0.0
+
+
+def _get_memory_usage() -> float:
+    try:
+        with open('/proc/meminfo') as fh:
+            meminfo = {line.split(':')[0]: int(line.split()[1]) for line in fh}
+        used = meminfo['MemTotal'] - meminfo['MemAvailable']
+        return used / meminfo['MemTotal'] * 100
+    except Exception:
+        return 0.0
+
+
+@dataclass
+class ResourceStats:
+    cpu: float
+    memory: float
+
+
+class ResourceMonitor:
+    async def get_stats(self) -> ResourceStats:
+        loop = asyncio.get_event_loop()
+        cpu, mem = await asyncio.gather(
+            loop.run_in_executor(None, _get_cpu_usage),
+            loop.run_in_executor(None, _get_memory_usage),
+        )
+        return ResourceStats(cpu=cpu, memory=mem)

--- a/infrastructure/task_queue.py
+++ b/infrastructure/task_queue.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Tuple
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+
+@dataclass
+class JobStatus:
+    status: str
+    progress: int = 0
+    error: str | None = None
+    result: dict | None = None
+
+
+class TaskQueue:
+    """Simple in-memory task queue for video generation jobs."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Tuple[str, BaseModel]] = asyncio.Queue()
+        self._jobs: Dict[str, JobStatus] = {}
+
+    async def enqueue_video_generation(self, request: BaseModel) -> str:
+        job_id = uuid4().hex
+        self._jobs[job_id] = JobStatus("queued")
+        await self._queue.put((job_id, request))
+        return job_id
+
+    async def get_job_status(self, job_id: str) -> JobStatus:
+        return self._jobs[job_id]
+
+    async def cancel_job(self, job_id: str) -> bool:
+        status = self._jobs.get(job_id)
+        if not status or status.status not in {"queued", "running"}:
+            return False
+        status.status = "cancelled"
+        return True
+
+    async def get_task(self) -> Tuple[str, BaseModel]:
+        return await self._queue.get()
+
+    def task_done(self) -> None:
+        self._queue.task_done()

--- a/infrastructure/worker_manager.py
+++ b/infrastructure/worker_manager.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Awaitable, Callable, List
+
+from .task_queue import TaskQueue, JobStatus
+
+
+class WorkerManager:
+    def __init__(
+        self,
+        queue: TaskQueue,
+        worker_fn: Callable[[str, object], Awaitable[None]],
+    ) -> None:
+        self.queue = queue
+        self.worker_fn = worker_fn
+        self.workers: List[asyncio.Task] = []
+
+    @property
+    def worker_count(self) -> int:
+        return len(self.workers)
+
+    async def start(self, count: int) -> None:
+        for _ in range(count):
+            self.workers.append(asyncio.create_task(self._worker_loop()))
+
+    async def scale(self, count: int) -> None:
+        diff = count - self.worker_count
+        if diff > 0:
+            await self.start(diff)
+        else:
+            for _ in range(-diff):
+                task = self.workers.pop()
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    async def stop(self) -> None:
+        await self.scale(0)
+
+    async def _worker_loop(self) -> None:
+        while True:
+            job_id, req = await self.queue.get_task()
+            status = await self.queue.get_job_status(job_id)
+            if status.status == "cancelled":
+                self.queue.task_done()
+                continue
+            status.status = "running"
+            try:
+                await self.worker_fn(job_id, req)
+                status.status = "completed"
+                status.progress = 100
+            except Exception as exc:  # pragma: no cover - safety net
+                status.status = "failed"
+                status.error = str(exc)
+            finally:
+                self.queue.task_done()

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -11,10 +11,17 @@ from ai_video_pipeline import api_app
 
 
 @pytest.fixture(autouse=True)
-def patch_run(monkeypatch):
-    async def fake_run(job_id, req):
-        api_app._jobs[job_id]["status"] = "completed"
-    monkeypatch.setattr(api_app, '_run_job', fake_run)
+def patch_queue(monkeypatch):
+    async def fake_enqueue(req):
+        job_id = "test_job"
+        api_app.queue._jobs[job_id] = api_app.JobStatus("completed")
+        return job_id
+
+    async def fake_status(job_id: str):
+        return api_app.queue._jobs[job_id]
+
+    monkeypatch.setattr(api_app.queue, "enqueue_video_generation", fake_enqueue)
+    monkeypatch.setattr(api_app.queue, "get_job_status", fake_status)
 
 
 def test_generate_and_status(monkeypatch):

--- a/tests/test_pipeline_distributed.py
+++ b/tests/test_pipeline_distributed.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from pipeline import ContentPipeline
+from config import Config
+from services.container import Container
+
+
+class DummyIdea:
+    async def generate(self):
+        return {"idea": "x", "prompt": "p"}
+
+
+class DummyImage:
+    async def generate(self, prompt: str):
+        return "img.png"
+
+
+class DummyVideo:
+    async def generate(self, prompt: str, **kwargs):
+        return "vid.mp4"
+
+
+class DummyMusic:
+    async def generate(self, prompt: str):
+        return "music.mp3"
+
+
+@pytest.mark.asyncio
+async def test_run_multiple_videos_distributed(monkeypatch):
+    cfg = Config("sk", "sa", "rep", 60)
+    container = Container()
+    container.register_singleton("idea_generator", lambda: DummyIdea())
+    container.register_singleton("image_generator", lambda: DummyImage())
+    container.register_singleton("video_generator", lambda: DummyVideo())
+    container.register_singleton("music_generator", lambda: DummyMusic())
+    pipeline = ContentPipeline(cfg, container)
+
+    async def fake_merge(*args, **kwargs):
+        return "f.mp4"
+
+    monkeypatch.setattr("pipeline.merge_video_audio", fake_merge)
+
+    result = await pipeline.run_multiple_videos_distributed(4, workers=2)
+    assert len(result) == 4

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from infrastructure.task_queue import TaskQueue
+
+
+class DummyRequest(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_enqueue_status_cancel():
+    queue = TaskQueue()
+    job_id = await queue.enqueue_video_generation(DummyRequest())
+    status = await queue.get_job_status(job_id)
+    assert status.status == "queued"
+    cancelled = await queue.cancel_job(job_id)
+    assert cancelled
+    status = await queue.get_job_status(job_id)
+    assert status.status == "cancelled"

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -1,0 +1,30 @@
+import asyncio
+import sys
+from pathlib import Path
+import pytest
+from pydantic import BaseModel
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from infrastructure.task_queue import TaskQueue
+from infrastructure.worker_manager import WorkerManager
+
+
+class DummyRequest(BaseModel):
+    value: int = 1
+
+
+async def worker(job_id: str, req: DummyRequest) -> None:
+    await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_worker_manager_executes_job():
+    queue = TaskQueue()
+    manager = WorkerManager(queue, worker)
+    await manager.start(1)
+    job = await queue.enqueue_video_generation(DummyRequest())
+    await queue._queue.join()
+    status = await queue.get_job_status(job)
+    assert status.status == "completed"
+    await manager.stop()


### PR DESCRIPTION
## Summary
- add `infrastructure` module with task queue, worker manager, load balancer, resource monitor and autoscaler
- integrate queue into `api_app` with worker startup/shutdown
- support distributed execution via `run_multiple_videos_distributed`
- add unit tests for new infrastructure
- update existing tests for new API app behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68457a4718788322b9f50b7b55d7d98a