### PR TITLE
Fix test imports

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,7 +1,6 @@
 import asyncio
 from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
## Summary
- set `PYTHONPATH` for GitHub Actions
- clean up integration test imports

## Testing
- `pytest -k test_full_pipeline.py -vv` *(fails: cannot import name 'API_RESPONSE_TIME' from partially initialized module 'utils.monitoring')*

------
https://chatgpt.com/codex/tasks/task_e_684584e5eeb08322a4b1603919912794