### PR TITLE
Fix import issues in integration tests

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,7 +1,5 @@
 from .metrics_collector import MetricsCollector
 from .performance_tracker import PerformanceTracker
-from .alerting import AlertManager, Alert
-from .health_checks import ServiceHealthChecker
 from .tracing import PipelineTracer
 from .structured_logger import get_logger, set_correlation_id
 from .business_metrics import BusinessMetrics
@@ -11,9 +9,6 @@ from .dashboard_config import GRAFANA_DASHBOARD
 __all__ = [
     "MetricsCollector",
     "PerformanceTracker",
-    "AlertManager",
-    "Alert",
-    "ServiceHealthChecker",
     "PipelineTracer",
     "get_logger",
     "set_correlation_id",

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,5 +1,8 @@
 import asyncio
 from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 
 import pytest


### PR DESCRIPTION
## Summary
- prevent circular imports in `monitoring` package
- ensure integration tests can import project modules
- mark `tests` as a package for imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests/integration/test_full_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684586a9d41483229b5c6de9637e4b5e