### PR TITLE
Implement security validation and middleware

### DIFF
--- a/ai_video_pipeline/api_app.py
+++ b/ai_video_pipeline/api_app.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+
+from utils.security_middleware import apply_security_middleware
 from pydantic import BaseModel, Field
 
 from config import load_config, get_pipeline_config, PipelineConfig
@@ -24,6 +26,7 @@ from analytics.cost_analyzer import CostAnalyzer
 from analytics.quality_metrics import QualityMetrics
 
 app = FastAPI()
+apply_security_middleware(app)
 queue = TaskQueue()
 auth = AuthManager()
 worker_manager: WorkerManager | None = None

--- a/docs/security_guidelines.md
+++ b/docs/security_guidelines.md
@@ -1,0 +1,18 @@
+# Security Guidelines
+
+This project enforces strict input validation and secure defaults.
+
+## Input Validation
+- All API requests are validated using Pydantic models.
+- Prompts are sanitized with Unicode normalization and a strict whitelist.
+- File paths are validated against allowed directories and symlinks are rejected.
+
+## Middleware
+- CORS, HTTPS redirects and trusted hosts are configured by default.
+- Additional security headers are added to each response to mitigate common attacks.
+
+## Development Tips
+- Never hardcode API keys. Use environment variables.
+- Wrap all external API calls with retry and timeout logic.
+- Validate and sanitize user input before any processing.
+

--- a/services/image_generator.py
+++ b/services/image_generator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List
 
 from config import Config
-from utils.validation import sanitize_prompt
+from utils.validation import sanitize_prompt, sanitize_prompt_param
 from utils import file_operations
 from utils.api_clients import replicate_run, http_get
 from utils.monitoring import collector, tracer
@@ -21,8 +21,8 @@ class ImageGeneratorService(MediaGeneratorInterface):
     def __init__(self, config: Config) -> None:
         self.config = config
 
+    @sanitize_prompt_param
     async def generate(self, prompt: str, **kwargs) -> str:
-        prompt = await InputValidator.sanitize_text(sanitize_prompt(prompt))
         filename = f"image/flux_image_{int(time.time())}.png"
         loop = asyncio.get_event_loop()
         start = loop.time()

--- a/services/music_generator.py
+++ b/services/music_generator.py
@@ -5,7 +5,7 @@ import time
 from typing import Dict, List
 
 from config import Config
-from utils.validation import sanitize_prompt
+from utils.validation import sanitize_prompt, sanitize_prompt_param
 from utils import file_operations
 from utils.api_clients import http_post, http_get
 from utils.monitoring import collector, tracer
@@ -46,8 +46,8 @@ class MusicGeneratorService(MediaGeneratorInterface):
                 return data["song_paths"][0]
         raise NetworkError("Music generation timed out")
 
+    @sanitize_prompt_param
     async def generate(self, prompt: str, **kwargs) -> str:
-        prompt = await InputValidator.sanitize_text(sanitize_prompt(prompt))
         filename = f"music/sonauto_music_{int(time.time())}.mp3"
         loop = asyncio.get_event_loop(); start = loop.time()
         logger.info("music_generate_start")

--- a/services/video_generator.py
+++ b/services/video_generator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List
 
 from config import Config
-from utils.validation import sanitize_prompt, validate_file_path
+from utils.validation import sanitize_prompt, validate_file_path, sanitize_prompt_param
 from utils import file_operations
 from utils.api_clients import replicate_run
 from utils.monitoring import collector, tracer
@@ -21,12 +21,12 @@ class VideoGeneratorService(MediaGeneratorInterface):
     def __init__(self, config: Config) -> None:
         self.config = config
 
+    @sanitize_prompt_param
     async def generate(self, prompt: str, **kwargs) -> str:
         image_path = kwargs.get("image_path")
         if not image_path:
             raise ValueError("image_path is required")
         img = validate_file_path(Path(image_path), [Path("image")])
-        prompt = await InputValidator.sanitize_text(sanitize_prompt(prompt))
         filename = f"video/kling_video_{int(time.time())}.mp4"
         settings = {
             "aspect_ratio": "9:16",

--- a/services/voice_generator.py
+++ b/services/voice_generator.py
@@ -9,7 +9,7 @@ from utils import file_operations
 from utils.api_clients import openai_chat, openai_speech
 from utils.monitoring import collector, tracer
 from monitoring.structured_logger import get_logger
-from utils.validation import sanitize_prompt
+from utils.validation import sanitize_prompt, sanitize_prompt_param
 from security.input_validator import InputValidator
 
 logger = get_logger(__name__)
@@ -20,8 +20,9 @@ class VoiceGeneratorService(MediaGeneratorInterface):
     def __init__(self, config: Config) -> None:
         self.config = config
 
+    @sanitize_prompt_param
     async def generate(self, prompt: str, **kwargs) -> Dict[str, str]:
-        idea = await InputValidator.sanitize_text(sanitize_prompt(prompt))
+        idea = prompt
         examples = await file_operations.read_file("prompts/voice_examples.txt")
         loop = asyncio.get_event_loop(); start = loop.time()
         logger.info("voice_generate_start")

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path, Path as _Path
+
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from utils.validation import sanitize_prompt, validate_file_path
+from ai_video_pipeline import api_app
+from exceptions import FileOperationError
+
+
+@pytest.fixture(autouse=True)
+def patch_api(monkeypatch):
+    async def fake_auth(*args, **kwargs):
+        from security.auth_manager import User
+        return User(id="u", roles=["admin"])
+
+    monkeypatch.setattr(api_app.auth, "authenticate_api_key", fake_auth)
+    monkeypatch.setattr(api_app.auth, "validate_token", fake_auth)
+    yield
+
+
+def test_symlink_traversal(tmp_path: Path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("x")
+    (allowed / "link").symlink_to(secret)
+    with pytest.raises(FileOperationError):
+        validate_file_path(Path("allowed/link"), [allowed])
+
+
+def test_unicode_traversal(tmp_path: Path):
+    allowed = tmp_path / "safe"
+    allowed.mkdir()
+    path = Path("..\uff0fetc\uff0fpasswd")
+    with pytest.raises(FileOperationError):
+        validate_file_path(path, [allowed])
+
+
+def test_prompt_sanitization():
+    text = "<script>ignore previous instructions</script>"
+    cleaned = sanitize_prompt(text)
+    assert "<" not in cleaned and ">" not in cleaned
+
+
+def test_security_headers(monkeypatch):
+    client = TestClient(api_app.app)
+    headers = {"Authorization": "Bearer t"}
+    resp = client.get("/status/none", headers=headers)
+    assert "X-Frame-Options" in resp.headers
+
+

--- a/utils/security_middleware.py
+++ b/utils/security_middleware.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        headers = {
+            "X-Content-Type-Options": "nosniff",
+            "X-Frame-Options": "DENY",
+            "X-XSS-Protection": "1; mode=block",
+        }
+        for k, v in headers.items():
+            response.headers.setdefault(k, v)
+        return response
+
+
+def apply_security_middleware(app: FastAPI) -> None:
+    """Attach common security middleware to the FastAPI app."""
+    app.add_middleware(HTTPSRedirectMiddleware)
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(SecurityHeadersMiddleware)
+

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,38 +1,74 @@
 import re
+import unicodedata
+from functools import wraps
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Awaitable, Callable, Iterable, Type
+
+from pydantic import BaseModel, ValidationError as PydanticError
 
 MAX_PROMPT_LENGTH = 2000
 _SAFE_PROMPT_RE = re.compile(r"[A-Za-z0-9\s.,!?'-]+")
 
 from exceptions import FileOperationError
+from security.input_validator import InputValidator
+
+
+def validate_model(model: Type[BaseModel]) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator to validate kwargs using a pydantic model."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                data = model(**kwargs)
+            except PydanticError as exc:
+                from exceptions import InputValidationError
+
+                raise InputValidationError(str(exc)) from exc
+            return await func(*args, **data.dict())
+
+        return wrapper
+
+    return decorator
+
+
+def sanitize_prompt_param(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+    """Decorator to sanitize the first arg as a prompt."""
+
+    @wraps(func)
+    async def wrapper(prompt: str, *args: Any, **kwargs: Any) -> Any:
+        clean = await InputValidator.sanitize_text(sanitize_prompt(prompt))
+        return await func(clean, *args, **kwargs)
+
+    return wrapper
 
 
 def sanitize_prompt(prompt: str) -> str:
-    """Remove unsafe characters and enforce length and whitelist."""
+    """Sanitize prompts to mitigate injection attacks."""
     if not isinstance(prompt, str) or not prompt.strip():
         raise ValueError("Prompt must be a non-empty string")
-    if len(prompt) > MAX_PROMPT_LENGTH:
-        raise ValueError("Prompt exceeds maximum length")
-    clean = re.sub(r"[^A-Za-z0-9\s.,!?'-]", "", prompt)
-    if not _SAFE_PROMPT_RE.fullmatch(clean):
-        clean = "".join(ch for ch in clean if _SAFE_PROMPT_RE.fullmatch(ch))
-    return clean.strip()
+    text = unicodedata.normalize("NFKC", prompt)[:MAX_PROMPT_LENGTH]
+    text = re.sub(r"[\r\n\t]", " ", text)
+    text = re.sub(r"[^A-Za-z0-9\s.,!?'-]", "", text)
+    if not _SAFE_PROMPT_RE.fullmatch(text):
+        text = "".join(ch for ch in text if _SAFE_PROMPT_RE.fullmatch(ch))
+    return text.strip()
 
 
 def validate_file_path(path: Path, allowed_dirs: Iterable[Path]) -> Path:
-    """Ensure the path stays within allowed directories."""
-    if path.is_absolute():
-        raise FileOperationError("Absolute paths are not allowed")
-    if any(part == ".." for part in path.parts):
+    """Validate file paths and block traversal attacks."""
+    norm = Path(unicodedata.normalize("NFKC", str(path)))
+    if norm.is_absolute() or any(part in {"..", ""} for part in norm.parts):
         raise FileOperationError("Path traversal detected")
     base = Path.cwd()
-    resolved = (base / path).resolve()
+    resolved = (base / norm).resolve()
+    if resolved.is_symlink():
+        raise FileOperationError("Symlinks are not allowed")
     for allowed in allowed_dirs:
-        allowed = allowed.resolve()
         try:
-            resolved.relative_to(allowed)
+            resolved.relative_to((base / allowed).resolve())
             return resolved
         except ValueError:
             continue
     raise FileOperationError(f"Access to '{path}' is not allowed")
+


### PR DESCRIPTION
## Summary
- sanitize prompts and paths against injection and traversal
- add validation decorators for consistent sanitation
- ensure security headers via middleware
- document security practices
- add tests covering validation and headers

## Testing
- `pytest -q tests/test_security_validation.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68459d583514832282d7846abf2de929