### PR TITLE
Implement parallel pipeline scheduler

### DIFF
--- a/performance/benchmarks.py
+++ b/performance/benchmarks.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import List
+
+from pipeline.parallel_scheduler import ParallelPipelineScheduler
+from pipeline.stages import PipelineContext, PipelineStage
+
+
+class DummyStage(PipelineStage):
+    def __init__(self, name: str, delay: float, requires: set[str] | None = None) -> None:
+        self.name = name
+        self.delay = delay
+        self.requires = requires or set()
+
+    async def execute(self, ctx: PipelineContext) -> PipelineContext:
+        await asyncio.sleep(self.delay)
+        ctx.meta[self.name] = True
+        return ctx
+
+
+async def run_benchmark() -> float:
+    stages: List[PipelineStage] = [
+        DummyStage("a", 0.1),
+        DummyStage("b", 0.1, {"a"}),
+        DummyStage("c", 0.1, {"a"}),
+        DummyStage("d", 0.1, {"b", "c"}),
+    ]
+    scheduler = ParallelPipelineScheduler()
+    start = time.perf_counter()
+    await scheduler.execute_pipeline(stages, PipelineContext())
+    return time.perf_counter() - start
+
+
+if __name__ == "__main__":
+    result = asyncio.run(run_benchmark())
+    print(f"Execution time: {result:.2f}s")

--- a/pipeline/parallel_scheduler.py
+++ b/pipeline/parallel_scheduler.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List, Dict, Set
+
+from .stages import PipelineStage, PipelineContext
+
+
+class StageExecutionError(Exception):
+    """Raised when a pipeline stage fails."""
+
+
+class ParallelPipelineScheduler:
+    def __init__(self, concurrency: int = 4) -> None:
+        self.sem = asyncio.Semaphore(concurrency)
+
+    def _dependency_graph(
+        self, stages: Iterable[PipelineStage]
+    ) -> List[List[PipelineStage]]:
+        stage_map: Dict[str, PipelineStage] = {s.name: s for s in stages}
+        in_deg: Dict[str, int] = {
+            s.name: len(getattr(s, "requires", set())) for s in stages
+        }
+        deps: Dict[str, List[str]] = {s.name: [] for s in stages}
+        for s in stages:
+            for dep in getattr(s, "requires", set()):
+                deps.setdefault(dep, []).append(s.name)
+        queue = [n for n, d in in_deg.items() if d == 0]
+        groups: List[List[PipelineStage]] = []
+        while queue:
+            groups.append([stage_map[n] for n in queue])
+            next_q: List[str] = []
+            for n in queue:
+                for child in deps.get(n, []):
+                    in_deg[child] -= 1
+                    if in_deg[child] == 0:
+                        next_q.append(child)
+            queue = next_q
+        if any(d > 0 for d in in_deg.values()):
+            raise ValueError("Cyclic dependencies detected")
+        return groups
+
+    async def _run_stage(
+        self, stage: PipelineStage, ctx: PipelineContext
+    ) -> PipelineContext:
+        async with self.sem:
+            try:
+                copy = PipelineContext(**vars(ctx))
+                return await stage.execute(copy)
+            except Exception as exc:
+                raise StageExecutionError(stage.name) from exc
+
+    @staticmethod
+    def _merge(results: Iterable[PipelineContext], ctx: PipelineContext) -> PipelineContext:
+        for res in results:
+            for key, value in vars(res).items():
+                if value is not None:
+                    setattr(ctx, key, value)
+        return ctx
+
+    async def execute_pipeline(
+        self, stages: Iterable[PipelineStage], ctx: PipelineContext | None = None
+    ) -> PipelineContext:
+        ctx = ctx or PipelineContext()
+        groups = self._dependency_graph(list(stages))
+        for group in groups:
+            tasks = [self._run_stage(s, ctx) for s in group]
+            results = await asyncio.gather(*tasks)
+            ctx = self._merge(results, ctx)
+        return ctx

--- a/tests/test_parallel_pipeline.py
+++ b/tests/test_parallel_pipeline.py
@@ -1,0 +1,125 @@
+import asyncio
+from pathlib import Path as _Path
+import importlib.util
+import types
+import sys
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+import pytest
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any, Set
+
+BASE = _Path(__file__).resolve().parents[1]
+
+# Stub pipeline.stages to satisfy imports
+stages_stub = types.ModuleType("pipeline.stages")
+
+@dataclass
+class PipelineContext:
+    idea: Optional[str] = None
+    prompt: Optional[str] = None
+    image_path: Optional[str] = None
+    video_path: Optional[str] = None
+    music_path: Optional[str] = None
+    voice: Optional[Dict[str, str]] = None
+    output: Optional[str] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+class PipelineStage:
+    name: str
+    requires: Set[str] = set()
+
+    async def execute(self, ctx: PipelineContext) -> PipelineContext:
+        raise NotImplementedError
+
+stages_stub.PipelineContext = PipelineContext
+stages_stub.PipelineStage = PipelineStage
+sys.modules["pipeline.stages"] = stages_stub
+
+# Create package context
+pipeline_pkg = types.ModuleType("pipeline")
+pipeline_pkg.__path__ = [str(BASE / "pipeline")]
+sys.modules.setdefault("pipeline", pipeline_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "pipeline.parallel_scheduler", BASE / "pipeline" / "parallel_scheduler.py"
+)
+parallel_mod = importlib.util.module_from_spec(spec)
+sys.modules["pipeline.parallel_scheduler"] = parallel_mod
+spec.loader.exec_module(parallel_mod)
+ParallelPipelineScheduler = parallel_mod.ParallelPipelineScheduler
+
+from utils.streaming_io import stream_copy, stream_write
+from utils.connection_pool import get_session, close_all
+from utils.caching_layer import ResponseCache
+
+
+class DummyStage(PipelineStage):
+    def __init__(self, name: str, requires=None) -> None:
+        self.name = name
+        self.requires = requires or set()
+
+    async def execute(self, ctx: PipelineContext) -> PipelineContext:
+        ctx.meta[self.name] = True
+        return ctx
+
+
+@pytest.mark.asyncio
+async def test_dependency_grouping() -> None:
+    stages = [
+        DummyStage("a"),
+        DummyStage("b", {"a"}),
+        DummyStage("c", {"a"}),
+        DummyStage("d", {"b", "c"}),
+    ]
+    scheduler = ParallelPipelineScheduler()
+    groups = scheduler._dependency_graph(stages)
+    assert len(groups) == 3
+    assert {s.name for s in groups[0]} == {"a"}
+    assert {s.name for s in groups[1]} == {"b", "c"}
+    assert {s.name for s in groups[2]} == {"d"}
+
+
+@pytest.mark.asyncio
+async def test_execute_pipeline() -> None:
+    stages = [
+        DummyStage("a"),
+        DummyStage("b", {"a"}),
+        DummyStage("c", {"a"}),
+    ]
+    scheduler = ParallelPipelineScheduler()
+    ctx = await scheduler.execute_pipeline(stages, PipelineContext())
+    assert ctx.meta == {"a": True, "b": True, "c": True}
+
+
+@pytest.mark.asyncio
+async def test_stream_copy(tmp_path: _Path) -> None:
+    src = tmp_path / "src.txt"
+    dest = tmp_path / "dest.txt"
+    async def gen():
+        yield b"x"
+
+    await stream_write(src, gen())
+    await stream_copy(src, dest)
+    assert dest.read_bytes() == b"x"
+
+
+@pytest.mark.asyncio
+async def test_connection_pool_reuse() -> None:
+    s1 = await get_session("https://example.com", 5)
+    s2 = await get_session("https://example.com", 5)
+    assert s1 is s2
+    await close_all()
+
+
+@pytest.mark.asyncio
+async def test_response_cache() -> None:
+    cache = ResponseCache(ttl=1)
+
+    async def creator() -> str:
+        return "value"
+
+    v1 = await cache.get_or_set("k", creator)
+    v2 = await cache.get_or_set("k", creator)
+    assert v1 == v2
+    assert cache.get("k") == "value"

--- a/utils/caching_layer.py
+++ b/utils/caching_layer.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Tuple, Callable, Awaitable
+
+
+class ResponseCache:
+    def __init__(self, ttl: int = 300, max_items: int = 256) -> None:
+        self.ttl = ttl
+        self.max_items = max_items
+        self._cache: Dict[str, Tuple[float, Any]] = {}
+
+    def _prune(self) -> None:
+        now = time.time()
+        keys = [k for k, (t, _) in self._cache.items() if now - t > self.ttl]
+        for k in keys:
+            self._cache.pop(k, None)
+        while len(self._cache) > self.max_items:
+            self._cache.pop(next(iter(self._cache)))
+
+    def get(self, key: str) -> Any | None:
+        item = self._cache.get(key)
+        if item and time.time() - item[0] < self.ttl:
+            return item[1]
+        return None
+
+    async def get_or_set(
+        self, key: str, func: Callable[[], Awaitable[Any]]
+    ) -> Any:
+        hit = self.get(key)
+        if hit is not None:
+            return hit
+        value = await func()
+        self._cache[key] = (time.time(), value)
+        self._prune()
+        return value
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/utils/connection_pool.py
+++ b/utils/connection_pool.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import aiohttp
+from typing import Dict, Tuple
+
+_sessions: Dict[Tuple[str, int], aiohttp.ClientSession] = {}
+
+
+async def get_session(base_url: str, timeout: int = 60) -> aiohttp.ClientSession:
+    """Return or create a pooled HTTP session."""
+    key = (base_url, timeout)
+    session = _sessions.get(key)
+    if session is None or session.closed:
+        connector = aiohttp.TCPConnector(limit=20, keepalive_timeout=30)
+        _sessions[key] = aiohttp.ClientSession(
+            base_url=base_url,
+            connector=connector,
+            timeout=aiohttp.ClientTimeout(total=timeout),
+        )
+        session = _sessions[key]
+    return session
+
+
+async def close_all() -> None:
+    for session in list(_sessions.values()):
+        if not session.closed:
+            await session.close()
+    _sessions.clear()

--- a/utils/streaming_io.py
+++ b/utils/streaming_io.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterable
+
+from optimization.memory_manager import MemoryManager
+
+
+async def stream_write(dest: Path, data: AsyncIterable[bytes], chunk_size: int = 65536) -> None:
+    """Write data to file asynchronously using buffered chunks."""
+    loop = asyncio.get_event_loop()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "wb") as w:
+        async for chunk in data:
+            await loop.run_in_executor(None, w.write, chunk)
+
+
+async def stream_copy(src: Path, dest: Path, chunk_size: int = 65536) -> None:
+    """Copy file contents asynchronously."""
+    async def _reader() -> AsyncIterable[bytes]:
+        async for c in MemoryManager.stream_file(src, chunk_size):
+            yield c
+    await stream_write(dest, _reader(), chunk_size)


### PR DESCRIPTION
## Summary
- add new `ParallelPipelineScheduler` for dependency-aware parallel execution
- implement streaming file helpers
- implement connection pooling and response caching utilities
- add benchmarking script
- cover new functionality with tests

## Testing
- `pytest -q tests/test_parallel_pipeline.py`
- `pytest -q` *(fails: 32 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_6845a6ef77cc83229f1bd9aed3a64227