### PR TITLE
Implement repository pattern with DI

### DIFF
--- a/infrastructure/di_container.py
+++ b/infrastructure/di_container.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+class DIContainer:
+    """Lightweight dependency injection container."""
+
+    def __init__(self) -> None:
+        self._singletons: Dict[Any, Callable[[], Any]] = {}
+        self._instances: Dict[Any, Any] = {}
+        self._factories: Dict[Any, Callable[[], Any]] = {}
+
+    def register_singleton(self, key: Any, provider: Callable[[], Any]) -> None:
+        self._singletons[key] = provider
+
+    def register_factory(self, key: Any, factory: Callable[[], Any]) -> None:
+        self._factories[key] = factory
+
+    def resolve(self, key: Any) -> Any:
+        if key in self._instances:
+            return self._instances[key]
+        if key in self._singletons:
+            self._instances[key] = self._singletons[key]()
+            return self._instances[key]
+        if key in self._factories:
+            return self._factories[key]()
+        raise KeyError(f"Service {key} not registered")
+
+    def __getitem__(self, key: Any) -> Any:
+        return self.resolve(key)

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import uuid
 
 from config import Config
-from services.container import Container
+from infrastructure.di_container import DIContainer
 from utils.media_processing import merge_video_audio
 from monitoring.structured_logger import set_correlation_id
 from utils.monitoring import tracer, record_profiling_metrics
@@ -29,7 +29,7 @@ from .progress import ProgressTracker
 
 
 class ContentPipeline:
-    def __init__(self, config: Config, container: Container) -> None:
+    def __init__(self, config: Config, container: DIContainer) -> None:
         self.config = config
         self.container = container
         self.pipeline_id = uuid.uuid4().hex

--- a/repositories/config_repository.py
+++ b/repositories/config_repository.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class ConfigRepository(ABC):
+    """Abstraction for configuration storage."""
+
+    @abstractmethod
+    async def get_config(self, key: str) -> Optional[str]:
+        """Retrieve configuration value."""
+
+    @abstractmethod
+    async def set_config(self, key: str, value: str) -> None:
+        """Persist configuration value."""

--- a/repositories/implementations/__init__.py
+++ b/repositories/implementations/__init__.py
@@ -1,0 +1,13 @@
+"""Concrete repository implementations."""
+
+from .local_media_repository import LocalMediaRepository
+from .s3_media_repository import S3MediaRepository
+from .in_memory_media_repository import InMemoryMediaRepository
+from .caching_media_repository import CachingMediaRepository
+
+__all__ = [
+    "LocalMediaRepository",
+    "S3MediaRepository",
+    "InMemoryMediaRepository",
+    "CachingMediaRepository",
+]

--- a/repositories/implementations/caching_media_repository.py
+++ b/repositories/implementations/caching_media_repository.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, Dict
+
+from ..media_repository import MediaRepository
+
+
+class CachingMediaRepository(MediaRepository):
+    """Cache decorator for another MediaRepository."""
+
+    def __init__(self, repo: MediaRepository) -> None:
+        self._repo = repo
+        self._cache: Dict[str, bytes] = {}
+
+    async def save_media(self, path: str, data: AsyncIterator[bytes]) -> str:
+        buf = bytearray()
+        async for chunk in data:
+            buf.extend(chunk)
+        self._cache[path] = bytes(buf)
+        async def _reader() -> AsyncIterator[bytes]:
+            yield self._cache[path]
+        await self._repo.save_media(path, _reader())
+        return path
+
+    async def load_media(self, path: str) -> AsyncIterator[bytes]:
+        if path not in self._cache:
+            chunks = []
+            async for chunk in self._repo.load_media(path):
+                chunks.append(chunk)
+            self._cache[path] = b"".join(chunks)
+        yield self._cache[path]

--- a/repositories/implementations/in_memory_media_repository.py
+++ b/repositories/implementations/in_memory_media_repository.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, Dict
+
+from ..media_repository import MediaRepository
+
+
+class InMemoryMediaRepository(MediaRepository):
+    """Simple in-memory media storage for testing."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, bytes] = {}
+
+    async def save_media(self, path: str, data: AsyncIterator[bytes]) -> str:
+        buf = bytearray()
+        async for chunk in data:
+            buf.extend(chunk)
+        self._store[path] = bytes(buf)
+        return path
+
+    async def load_media(self, path: str) -> AsyncIterator[bytes]:
+        if path in self._store:
+            yield self._store[path]
+        else:
+            yield b""

--- a/repositories/implementations/local_media_repository.py
+++ b/repositories/implementations/local_media_repository.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+from exceptions import FileOperationError
+from utils import file_operations
+
+from ..media_repository import MediaRepository
+
+
+class LocalMediaRepository(MediaRepository):
+    """Store media files on the local filesystem."""
+
+    async def save_media(self, path: str, data: AsyncIterator[bytes]) -> str:
+        async def _writer() -> AsyncIterator[bytes]:
+            async for chunk in data:
+                yield chunk
+
+        try:
+            await file_operations.save_file_stream(path, _writer())
+            return path
+        except FileOperationError:
+            raise
+        except Exception as exc:
+            raise FileOperationError(str(exc)) from exc
+
+    async def load_media(self, path: str) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in file_operations.read_file_stream(path):
+                yield chunk
+        except FileOperationError:
+            raise
+        except Exception as exc:
+            raise FileOperationError(str(exc)) from exc

--- a/repositories/implementations/s3_media_repository.py
+++ b/repositories/implementations/s3_media_repository.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import boto3
+from botocore.exceptions import BotoCoreError
+
+from exceptions import ServiceError
+from utils.api import api_call_with_retry
+
+from ..media_repository import MediaRepository
+
+
+class S3MediaRepository(MediaRepository):
+    """Media storage backed by S3."""
+
+    def __init__(self, bucket: str, prefix: str = "") -> None:
+        self._bucket = bucket
+        self._prefix = prefix
+        self._client = boto3.client("s3")
+
+    async def _put(self, key: str, body: bytes) -> None:
+        await asyncio.to_thread(self._client.put_object, Bucket=self._bucket, Key=key, Body=body)
+
+    async def _get(self, key: str) -> bytes:
+        resp = await asyncio.to_thread(self._client.get_object, Bucket=self._bucket, Key=key)
+        return await asyncio.to_thread(resp["Body"].read)
+
+    async def save_media(self, path: str, data: AsyncIterator[bytes]) -> str:
+        key = f"{self._prefix}{path}"
+        buf = bytearray()
+        async for chunk in data:
+            buf.extend(chunk)
+        try:
+            await api_call_with_retry("s3_put", lambda: self._put(key, bytes(buf)))
+            return path
+        except BotoCoreError as exc:
+            raise ServiceError(str(exc)) from exc
+
+    async def load_media(self, path: str) -> AsyncIterator[bytes]:
+        key = f"{self._prefix}{path}"
+        try:
+            data = await api_call_with_retry("s3_get", lambda: self._get(key))
+        except BotoCoreError as exc:
+            raise ServiceError(str(exc)) from exc
+        yield data

--- a/repositories/media_repository.py
+++ b/repositories/media_repository.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+
+class MediaRepository(ABC):
+    """Abstract storage for media files."""
+
+    @abstractmethod
+    async def save_media(self, path: str, data: AsyncIterator[bytes]) -> str:
+        """Persist media data and return the storage path."""
+
+    @abstractmethod
+    async def load_media(self, path: str) -> AsyncIterator[bytes]:
+        """Stream media data from storage."""

--- a/repositories/metrics_repository.py
+++ b/repositories/metrics_repository.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class MetricsRepository(ABC):
+    """Abstraction for metrics collection."""
+
+    @abstractmethod
+    async def record_metric(self, name: str, value: float, tags: Dict[str, str]) -> None:
+        """Store a metric value with tags."""

--- a/services/factory.py
+++ b/services/factory.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from config import Config
 
-from .container import Container
+from infrastructure.di_container import DIContainer
+from repositories.implementations import (
+    LocalMediaRepository,
+    InMemoryMediaRepository,
+    CachingMediaRepository,
+)
 from .idea_generator import IdeaGeneratorService
 from .image_generator import ImageGeneratorService
 from .video_generator import VideoGeneratorService
@@ -10,11 +15,34 @@ from .music_generator import MusicGeneratorService
 from .voice_generator import VoiceGeneratorService
 
 
-def create_services(config: Config, container: Container | None = None) -> Container:
-    container = container or Container()
+def create_services(
+    config: Config,
+    container: DIContainer | None = None,
+    backend: str = "local",
+) -> DIContainer:
+    container = container or DIContainer()
+    if backend == "memory":
+        repo = InMemoryMediaRepository()
+    else:
+        repo = LocalMediaRepository()
+    if backend == "cache":
+        repo = CachingMediaRepository(repo)
+    container.register_singleton("media_repository", lambda: repo)
     container.register_singleton("idea_generator", lambda: IdeaGeneratorService(config))
-    container.register_singleton("image_generator", lambda: ImageGeneratorService(config))
-    container.register_singleton("video_generator", lambda: VideoGeneratorService(config))
-    container.register_singleton("music_generator", lambda: MusicGeneratorService(config))
-    container.register_singleton("voice_generator", lambda: VoiceGeneratorService(config))
+    container.register_singleton(
+        "image_generator",
+        lambda: ImageGeneratorService(config, container["media_repository"]),
+    )
+    container.register_singleton(
+        "video_generator",
+        lambda: VideoGeneratorService(config, container["media_repository"]),
+    )
+    container.register_singleton(
+        "music_generator",
+        lambda: MusicGeneratorService(config, container["media_repository"]),
+    )
+    container.register_singleton(
+        "voice_generator",
+        lambda: VoiceGeneratorService(config, container["media_repository"]),
+    )
     return container

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
 from ai_video_pipeline import cli
-from services import container
+import infrastructure.di_container
 
 
 class DummyPipe:
@@ -27,7 +27,7 @@ def test_cli_generate(monkeypatch, tmp_path):
     monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890abcd')
     monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890abcd')
     monkeypatch.setattr(cli, 'ContentPipeline', lambda cfg, services: DummyPipe(cfg, services))
-    monkeypatch.setattr(cli, 'create_services', lambda cfg: container.Container())
+    monkeypatch.setattr(cli, 'create_services', lambda cfg: infrastructure.di_container.DIContainer())
     monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))
     out = tmp_path / 'out'
     cli.main(['generate', '--video-count', '2', '--output-dir', str(out)])

--- a/tests/test_di_container.py
+++ b/tests/test_di_container.py
@@ -1,0 +1,21 @@
+from infrastructure.di_container import DIContainer
+
+
+def test_singleton_resolution() -> None:
+    container = DIContainer()
+    container.register_singleton("x", lambda: 1)
+    assert container["x"] == 1
+    assert container["x"] is container["x"]
+
+
+def test_factory_resolution() -> None:
+    container = DIContainer()
+    counter = {"v": 0}
+
+    def factory() -> int:
+        counter["v"] += 1
+        return counter["v"]
+
+    container.register_factory("y", factory)
+    assert container["y"] == 1
+    assert container["y"] == 2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
 import main
-from services import container
+import infrastructure.di_container
 
 
 class DummyPipe:
@@ -33,7 +33,7 @@ def _patch(monkeypatch):
     monkeypatch.setenv('SONAUTO_API_KEY', 'sa-testsonauto1234567890abcd')
     monkeypatch.setenv('REPLICATE_API_KEY', 'r8_testreplicate1234567890abcd')
     monkeypatch.setattr(main, 'ContentPipeline', lambda cfg, svc: DummyPipe(cfg, svc))
-    monkeypatch.setattr(main, 'create_services', lambda cfg: container.Container())
+    monkeypatch.setattr(main, 'create_services', lambda cfg: infrastructure.di_container.DIContainer())
     monkeypatch.setattr(_Path, 'rename', lambda self, dst: _Path(dst).write_bytes(b''))
 
 

--- a/tests/test_media_repository_impl.py
+++ b/tests/test_media_repository_impl.py
@@ -1,0 +1,33 @@
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from repositories.implementations.in_memory_media_repository import InMemoryMediaRepository
+from repositories.implementations.caching_media_repository import CachingMediaRepository
+
+
+async def _aiter(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+@pytest.mark.asyncio
+async def test_in_memory_roundtrip() -> None:
+    repo = InMemoryMediaRepository()
+    await repo.save_media("a.txt", _aiter(b"hi"))
+    chunks = [c async for c in repo.load_media("a.txt")]
+    assert b"".join(chunks) == b"hi"
+
+
+@pytest.mark.asyncio
+async def test_caching_repository() -> None:
+    base = InMemoryMediaRepository()
+    repo = CachingMediaRepository(base)
+    await repo.save_media("b.txt", _aiter(b"x"))
+    # first load goes through base
+    data1 = [c async for c in repo.load_media("b.txt")][0]
+    assert data1 == b"x"
+    base._store["b.txt"] = b"y"
+    # second load uses cache
+    data2 = [c async for c in repo.load_media("b.txt")][0]
+    assert data2 == b"x"


### PR DESCRIPTION
## Summary
- add `DIContainer` to manage singleton and factory services
- introduce repository interfaces and local/memory/S3 implementations
- refactor generator services to use `MediaRepository`
- provide factory helpers to configure repositories
- add unit tests for the new DI container and repositories

## Testing
- `pytest tests/test_di_container.py tests/test_media_repository_impl.py tests/test_services.py -q`
- `pytest -k "di_container or media_repository_impl or services" -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a91d1c348322b37c80f1c243481b