### PR TITLE
Add boto3 dependency and update workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest-cov
+          pip install -r requirements.txt
+          pip install pytest-cov
       - name: Cleanup Coverage Database
         run: rm -f .coverage
       - name: Run Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ cryptography
 opentelemetry-api
 opentelemetry-sdk
 psutil
+boto3==1.26.0


### PR DESCRIPTION
## Summary
- install boto3 for S3 media repository usage
- ensure GitHub actions install requirements before tests

## Testing
- `pytest -q` *(fails: 6 failed, 83 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac15c3c4832290c8519495fe77c0