### PR TITLE
Fix tracing import and workflow path

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,5 +20,7 @@ jobs:
           pip install pytest-cov
       - name: Cleanup Coverage Database
         run: rm -f .coverage
+      - name: Set up Python path
+        run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
       - name: Run Tests
         run: pytest --cov=./ --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,7 @@ cryptography
 
 opentelemetry-api
 opentelemetry-sdk
+opentelemetry-exporter-jaeger
+deprecated
 psutil
 boto3==1.26.0

--- a/tests/test_observability_tracing.py
+++ b/tests/test_observability_tracing.py
@@ -1,8 +1,16 @@
 from pathlib import Path
 import sys
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from observability.tracing import Tracing
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root))
+
+try:
+    from observability.tracing import Tracing
+except ImportError as e:
+    raise ImportError(
+        f"Failed to import 'observability.tracing': {e}. "
+        "Make sure the module exists and the Python path is correctly configured."
+    )
 
 
 def test_tracing_init():


### PR DESCRIPTION
## Summary
- improve module path handling for tracing tests
- add OpenTelemetry Jaeger exporter and deprecated packages
- ensure CI workflow explicitly sets PYTHONPATH

## Testing
- `pytest tests/test_observability_tracing.py -vv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845bb9e66e883228e2c744028d8d24b